### PR TITLE
Alias AST methods for better readability

### DIFF
--- a/lib/custom/no_magic_numbers.rb
+++ b/lib/custom/no_magic_numbers.rb
@@ -16,34 +16,38 @@ module Custom
     IVASGN_MSG = 'Do not use magic number instance variables'
     SEND_MSG = 'Do not use magic numbers to set properties'
 
-    def on_lvasgn(node)
-      return unless magic_number_lvar?(node)
+    def on_local_variable_assignment(node)
+      return unless magic_number_local_variable?(node)
 
       add_offense(node, location: :expression, message: LVASGN_MSG)
     end
+    alias on_lvasgn on_local_variable_assignment
 
-    def on_ivasgn(node)
-      return unless magic_number_ivar?(node)
+
+    def on_instance_variable_assignment(node)
+      return unless magic_number_instance_variable?(node)
 
       add_offense(node, location: :expression, message: IVASGN_MSG)
     end
+    alias on_ivasgn on_instance_variable_assignment
 
-    def on_send(node)
+    def on_message_send(node)
       return unless anonymous_setter_assign?(node)
 
       add_offense(node, location: :expression, message: SEND_MSG)
     end
+    alias on_send on_message_send
 
     private
 
-    def magic_number_lvar?(node)
+    def magic_number_local_variable?(node)
       return false unless node.lvasgn_type?
 
       value = node.children.last
       ILLEGAL_SCALAR_TYPES.include?(value.type)
     end
 
-    def magic_number_ivar?(node)
+    def magic_number_instance_variable?(node)
       return false unless node.ivasgn_type?
 
       value = node.children.last

--- a/lib/custom/no_magic_numbers.rb
+++ b/lib/custom/no_magic_numbers.rb
@@ -12,14 +12,14 @@ module Custom
   class NoMagicNumbers < ::RuboCop::Cop::Cop
     ILLEGAL_SCALAR_TYPES = %i[float int].freeze
     ASSIGNS_VIA_ATTR_WRITER_PATTERN = '(send ({send self} ... ) _ (${int float} _))'
-    LVASGN_MSG = 'Do not use magic number local variables'
-    IVASGN_MSG = 'Do not use magic number instance variables'
-    SEND_MSG = 'Do not use magic numbers to set properties'
+    LOCAL_VARIABLE_ASSIGN_MSG = 'Do not use magic number local variables'
+    INSTANCE_VARIABLE_ASSIGN_MSG = 'Do not use magic number instance variables'
+    SEND_METHOD_MSG = 'Do not use magic numbers to set properties'
 
     def on_local_variable_assignment(node)
       return unless magic_number_local_variable?(node)
 
-      add_offense(node, location: :expression, message: LVASGN_MSG)
+      add_offense(node, location: :expression, message: LOCAL_VARIABLE_ASSIGN_MSG)
     end
     alias on_lvasgn on_local_variable_assignment
 
@@ -27,14 +27,14 @@ module Custom
     def on_instance_variable_assignment(node)
       return unless magic_number_instance_variable?(node)
 
-      add_offense(node, location: :expression, message: IVASGN_MSG)
+      add_offense(node, location: :expression, message: INSTANCE_VARIABLE_ASSIGN_MSG)
     end
     alias on_ivasgn on_instance_variable_assignment
 
     def on_message_send(node)
       return unless magic_number_setter_assign?(node)
 
-      add_offense(node, location: :expression, message: SEND_MSG)
+      add_offense(node, location: :expression, message: SEND_METHOD_MSG)
     end
     alias on_send on_message_send
 

--- a/lib/custom/no_magic_numbers.rb
+++ b/lib/custom/no_magic_numbers.rb
@@ -32,7 +32,7 @@ module Custom
     alias on_ivasgn on_instance_variable_assignment
 
     def on_message_send(node)
-      return unless anonymous_setter_assign?(node)
+      return unless magic_number_setter_assign?(node)
 
       add_offense(node, location: :expression, message: SEND_MSG)
     end
@@ -54,7 +54,7 @@ module Custom
       ILLEGAL_SCALAR_TYPES.include?(value.type)
     end
 
-    def anonymous_setter_assign?(node)
+    def magic_number_setter_assign?(node)
       return false unless node.send_type?
       return false unless RuboCop::AST::NodePattern.new(ASSIGNS_VIA_ATTR_WRITER_PATTERN).match(node)
 

--- a/lib/custom/no_magic_numbers.rb
+++ b/lib/custom/no_magic_numbers.rb
@@ -34,7 +34,7 @@ module Custom
     alias on_ivasgn on_instance_variable_assignment # rubocop API method name
 
     def on_message_send(node)
-      return unless magic_number_setter_assign?(node)
+      return unless magic_number_method_argument?(node)
 
       if assignment?(node)
         add_offense(node, location: :expression, message: PROPERTY_MSG)
@@ -60,7 +60,7 @@ module Custom
       ILLEGAL_SCALAR_TYPES.include?(value.type)
     end
 
-    def magic_number_setter_assign?(node)
+    def magic_number_method_argument?(node)
       return false unless node.send_type?
 
       RuboCop::AST::NodePattern.new(MAGIC_NUMBER_ARGUMENT_PATTERN).match(node)

--- a/lib/custom/no_magic_numbers.rb
+++ b/lib/custom/no_magic_numbers.rb
@@ -21,7 +21,7 @@ module Custom
 
       add_offense(node, location: :expression, message: LOCAL_VARIABLE_ASSIGN_MSG)
     end
-    alias on_lvasgn on_local_variable_assignment
+    alias on_lvasgn on_local_variable_assignment # rubocop API method name
 
 
     def on_instance_variable_assignment(node)
@@ -29,14 +29,14 @@ module Custom
 
       add_offense(node, location: :expression, message: INSTANCE_VARIABLE_ASSIGN_MSG)
     end
-    alias on_ivasgn on_instance_variable_assignment
+    alias on_ivasgn on_instance_variable_assignment # rubocop API method name
 
     def on_message_send(node)
       return unless magic_number_setter_assign?(node)
 
       add_offense(node, location: :expression, message: SEND_METHOD_MSG)
     end
-    alias on_send on_message_send
+    alias on_send on_message_send # rubocop API method name
 
     private
 


### PR DESCRIPTION
## What

Alias the RuboCop cop methods that use AST naming

## Why 

These are not always very clear, and we should optimise for readability 

Closes #11