### PR TITLE
Add tests to ensure global variables are not prohibited

### DIFF
--- a/test/lib/no_magic_numbers_test.rb
+++ b/test/lib/no_magic_numbers_test.rb
@@ -117,7 +117,7 @@ module Custom
         end
       RUBY
 
-      assert_no_offenses("Custom/NoMagicNumbers")
+      refute_offense
     end
 
     def test_ignores_magic_floats_assigned_via_class_writers_on_another_object
@@ -127,7 +127,7 @@ module Custom
         end
       RUBY
 
-      assert_no_offenses("Custom/NoMagicNumbers")
+      refute_offense
     end
 
     private

--- a/test/lib/no_magic_numbers_test.rb
+++ b/test/lib/no_magic_numbers_test.rb
@@ -94,13 +94,17 @@ module Custom
       RUBY
 
       assert_no_offenses("Custom/NoMagicNumbers")
+
+      inspect_source(<<~RUBY)
+        $GLOBAL_VARIABLE = 1
+      RUBY
+
+      assert_no_offenses("Custom/NoMagicNumbers")
     end
 
     def test_detects_magic_floats_assigned_to_global_variables
       inspect_source(<<~RUBY)
-        def test_method
-          $GLOBAL_VARIABLE = 1.0
-        end
+        $GLOBAL_VARIABLE = 1.0
       RUBY
 
       assert_no_offenses("Custom/NoMagicNumbers")

--- a/test/lib/no_magic_numbers_test.rb
+++ b/test/lib/no_magic_numbers_test.rb
@@ -86,6 +86,26 @@ module Custom
       assert_offense('Do not use magic numbers to set properties')
     end
 
+    def test_detects_magic_integers_assigned_to_global_variables
+      inspect_source(<<~RUBY)
+        def test_method
+          $GLOBAL_VARIABLE = 1
+        end
+      RUBY
+
+      assert_no_offenses("Custom/NoMagicNumbers")
+    end
+
+    def test_detects_magic_floats_assigned_to_global_variables
+      inspect_source(<<~RUBY)
+        def test_method
+          $GLOBAL_VARIABLE = 1.0
+        end
+      RUBY
+
+      assert_no_offenses("Custom/NoMagicNumbers")
+    end
+
     private
 
     def cop

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,11 @@ module TestHelper
     assert_equal(cop.offenses.first.message, violation_message) if cop.offenses.any?
   end
 
+  def assert_no_offenses(cop_name = nil)
+    matching_offenses = cop_name.nil? ? cop.offenses : cop.offenses.select { _1.cop_name == cop_name }
+    assert_empty(matching_offenses, "Expected no offense to be detected but there was one")
+  end
+
   private
 
   def parse_source(source, file = nil)


### PR DESCRIPTION
## What 

Adds tests to ensure global variables can be assigned to magic numbers

## Why 

When adding rules to detect other types of magic numbers, we want to ensure these aren't reported as false positives 

Close #3 