### PR TITLE
Prohibit magic number arguments to unary methods

### DIFF
--- a/lib/custom/no_magic_numbers.rb
+++ b/lib/custom/no_magic_numbers.rb
@@ -11,10 +11,12 @@ module Custom
   # HOURS_IN_ONE_DAY = 24
   class NoMagicNumbers < ::RuboCop::Cop::Cop
     ILLEGAL_SCALAR_TYPES = %i[float int].freeze
-    MAGIC_NUMBER_ARGUMENT_PATTERN = '(send ({send self} ... ) _ (${int float} _))'
+    MAGIC_NUMBER_ARGUMENT_PATTERN = "(send ({send self} ... ) _ (${#{ILLEGAL_SCALAR_TYPES.join(' ')}} _))".freeze
     LVASGN_MSG = 'Do not use magic number local variables'
     IVASGN_MSG = 'Do not use magic number instance variables'
-    SEND_MSG = 'Do not use magic numbers to set properties'
+    PROPERTY_MSG = 'Do not use magic numbers to set properties'
+    UNARY_MSG = 'Do not use magic numbers in unary methods'
+    UNARY_LENGTH = 1
 
     def on_lvasgn(node)
       return unless magic_number_lvar?(node)
@@ -29,9 +31,13 @@ module Custom
     end
 
     def on_send(node)
-      return unless anonymous_setter_assign?(node)
+      return unless illegal_scalar_argument?(node)
 
-      add_offense(node, location: :expression, message: SEND_MSG)
+      if assignment?(node)
+        add_offense(node, location: :expression, message: PROPERTY_MSG)
+      elsif unary?(node)
+        add_offense(node, location: :expression, message: UNARY_MSG)
+      end
     end
 
     private
@@ -50,16 +56,23 @@ module Custom
       ILLEGAL_SCALAR_TYPES.include?(value.type)
     end
 
-    def anonymous_setter_assign?(node)
-      return false unless node.send_type?
-      return false unless RuboCop::AST::NodePattern.new(MAGIC_NUMBER_ARGUMENT_PATTERN).match(node)
-
-      _receiver_node, method_name, *_arg_nodes = *node
+    def assignment?(node)
       # Only match on method names that resemble assignments
-      return false unless method_name.end_with?('=')
+      method_name(node).end_with?('=')
+    end
 
-      value = node.children.last
-      ILLEGAL_SCALAR_TYPES.include?(value.type)
+    def unary?(node)
+      # Only match on method names that are unary invocations, so 1 character
+      # long
+      method_name(node).length == UNARY_LENGTH
+    end
+
+    def illegal_scalar_argument?(node)
+      RuboCop::AST::NodePattern.new(MAGIC_NUMBER_ARGUMENT_PATTERN).match(node)
+    end
+
+    def method_name(node)
+      node.to_a[1]
     end
   end
 end

--- a/test/lib/no_magic_numbers_test.rb
+++ b/test/lib/no_magic_numbers_test.rb
@@ -13,7 +13,7 @@ module Custom
         end
       RUBY
 
-      assert_offense('Do not use magic number instance variables')
+      assert_offense(described_class::IVASGN_MSG)
     end
 
     def test_detects_magic_floats_assigned_to_instance_variables
@@ -23,7 +23,7 @@ module Custom
         end
       RUBY
 
-      assert_offense('Do not use magic number instance variables')
+      assert_offense(described_class::IVASGN_MSG)
     end
 
     def test_detects_magic_integers_assigned_to_local_variables
@@ -33,7 +33,7 @@ module Custom
         end
       RUBY
 
-      assert_offense('Do not use magic number local variables')
+      assert_offense(described_class::LVASGN_MSG)
     end
 
     def test_detects_magic_floats_assigned_to_local_variables
@@ -43,7 +43,7 @@ module Custom
         end
       RUBY
 
-      assert_offense('Do not use magic number local variables')
+      assert_offense(described_class::LVASGN_MSG)
     end
 
     def test_detects_magic_integers_assigned_via_attr_writers_on_self
@@ -53,7 +53,7 @@ module Custom
         end
       RUBY
 
-      assert_offense('Do not use magic numbers to set properties')
+      assert_offense(described_class::PROPERTY_MSG)
     end
 
     def test_detects_magic_floats_assigned_via_attr_writers_on_self
@@ -63,7 +63,27 @@ module Custom
         end
       RUBY
 
-      assert_offense('Do not use magic numbers to set properties')
+      assert_offense(described_class::PROPERTY_MSG)
+    end
+
+    def test_detects_magic_integers_as_arguments_to_unary_methods
+      inspect_source(<<~RUBY)
+        def test_method
+          foo + 1
+        end
+      RUBY
+
+      assert_offense(described_class::UNARY_MSG)
+    end
+
+    def test_detects_magic_floats_as_arguments_to_unary_methods
+      inspect_source(<<~RUBY)
+        def test_method
+          foo + 1.0
+        end
+      RUBY
+
+      assert_offense(described_class::UNARY_MSG)
     end
 
     def test_detects_magic_integers_assigned_via_attr_writers_on_another_object
@@ -73,7 +93,7 @@ module Custom
         end
       RUBY
 
-      assert_offense('Do not use magic numbers to set properties')
+      assert_offense(described_class::PROPERTY_MSG)
     end
 
     def test_detects_magic_floats_assigned_via_attr_writers_on_another_object
@@ -83,7 +103,7 @@ module Custom
         end
       RUBY
 
-      assert_offense('Do not use magic numbers to set properties')
+      assert_offense(described_class::PROPERTY_MSG)
     end
 
     def test_ignores_magic_integers_as_arguments_to_methods_on_another_object
@@ -148,8 +168,12 @@ module Custom
 
     private
 
+    def described_class
+      Custom::NoMagicNumbers
+    end
+
     def cop
-      @cop ||= Custom::NoMagicNumbers.new(config)
+      @cop ||= described_class.new(config)
     end
 
     def config


### PR DESCRIPTION
Fixes https://github.com/Bodacious/no-magic-numbers-cop/issues/10

Based on https://github.com/Bodacious/no-magic-numbers-cop/pull/17, so merge that first