### PR TITLE
Refactor tests to use cop name in assertion

### DIFF
--- a/test/lib/no_magic_numbers_test.rb
+++ b/test/lib/no_magic_numbers_test.rb
@@ -146,6 +146,31 @@ module Custom
       refute_offense(cop.name)
     end
 
+    def test_detects_magic_integers_assigned_to_global_variables
+      inspect_source(<<~RUBY)
+        def test_method
+          $GLOBAL_VARIABLE = 1
+        end
+      RUBY
+
+      assert_no_offenses('Custom/NoMagicNumbers')
+
+      inspect_source(<<~RUBY)
+        $GLOBAL_VARIABLE = 1
+      RUBY
+
+      assert_no_offenses('Custom/NoMagicNumbers')
+    end
+
+    def test_detects_magic_floats_assigned_to_global_variables
+      inspect_source(<<~RUBY)
+        $GLOBAL_VARIABLE = 1.0
+      RUBY
+
+      assert_no_offenses('Custom/NoMagicNumbers')
+      refute_offense(cop.name)
+    end
+
     def test_ignores_magic_integers_assigned_via_class_writers_on_another_object
       inspect_source(<<~RUBY)
         def test_method

--- a/test/lib/no_magic_numbers_test.rb
+++ b/test/lib/no_magic_numbers_test.rb
@@ -153,13 +153,13 @@ module Custom
         end
       RUBY
 
-      assert_no_offenses('Custom/NoMagicNumbers')
+      assert_no_offenses(cop.name)
 
       inspect_source(<<~RUBY)
         $GLOBAL_VARIABLE = 1
       RUBY
 
-      assert_no_offenses('Custom/NoMagicNumbers')
+      assert_no_offenses(cop.name)
     end
 
     def test_detects_magic_floats_assigned_to_global_variables
@@ -167,7 +167,7 @@ module Custom
         $GLOBAL_VARIABLE = 1.0
       RUBY
 
-      assert_no_offenses('Custom/NoMagicNumbers')
+      assert_no_offenses(cop.name)
       refute_offense(cop.name)
     end
 
@@ -202,7 +202,7 @@ module Custom
     end
 
     def config
-      @config ||= RuboCop::Config.new('Custom/NoMagicNumbers' => { 'Enabled' => true })
+      @config ||= RuboCop::Config.new(cop.name => { 'Enabled' => true })
     end
   end
 end

--- a/test/lib/no_magic_numbers_test.rb
+++ b/test/lib/no_magic_numbers_test.rb
@@ -13,7 +13,7 @@ module Custom
         end
       RUBY
 
-      assert_offense(described_class::INSTANCE_VARIABLE_ASSIGN_MSG)
+      assert_offense(cop.name, described_class::INSTANCE_VARIABLE_ASSIGN_MSG)
     end
 
     def test_detects_magic_floats_assigned_to_instance_variables
@@ -23,7 +23,7 @@ module Custom
         end
       RUBY
 
-      assert_offense(described_class::INSTANCE_VARIABLE_ASSIGN_MSG)
+      assert_offense(cop.name, described_class::INSTANCE_VARIABLE_ASSIGN_MSG)
     end
 
     def test_detects_magic_integers_assigned_to_local_variables
@@ -33,7 +33,7 @@ module Custom
         end
       RUBY
 
-      assert_offense(described_class::LOCAL_VARIABLE_ASSIGN_MSG)
+      assert_offense(cop.name, described_class::LOCAL_VARIABLE_ASSIGN_MSG)
     end
 
     def test_detects_magic_floats_assigned_to_local_variables
@@ -43,7 +43,7 @@ module Custom
         end
       RUBY
 
-      assert_offense(described_class::LOCAL_VARIABLE_ASSIGN_MSG)
+      assert_offense(cop.name, described_class::LOCAL_VARIABLE_ASSIGN_MSG)
     end
 
     def test_detects_magic_integers_assigned_via_attr_writers_on_self
@@ -53,7 +53,7 @@ module Custom
         end
       RUBY
 
-      assert_offense(described_class::PROPERTY_MSG)
+      assert_offense(cop.name, described_class::PROPERTY_MSG)
     end
 
     def test_detects_magic_floats_assigned_via_attr_writers_on_self
@@ -63,7 +63,7 @@ module Custom
         end
       RUBY
 
-      assert_offense(described_class::PROPERTY_MSG)
+      assert_offense(cop.name, described_class::PROPERTY_MSG)
     end
 
     def test_detects_magic_integers_as_arguments_to_unary_methods
@@ -73,7 +73,7 @@ module Custom
         end
       RUBY
 
-      assert_offense(described_class::UNARY_MSG)
+      assert_offense(cop.name, described_class::UNARY_MSG)
     end
 
     def test_detects_magic_floats_as_arguments_to_unary_methods
@@ -83,7 +83,7 @@ module Custom
         end
       RUBY
 
-      assert_offense(described_class::UNARY_MSG)
+      assert_offense(cop.name, described_class::UNARY_MSG)
     end
 
     def test_detects_magic_integers_assigned_via_attr_writers_on_another_object
@@ -93,7 +93,7 @@ module Custom
         end
       RUBY
 
-      assert_offense(described_class::PROPERTY_MSG)
+      assert_offense(cop.name, described_class::PROPERTY_MSG)
     end
 
     def test_detects_magic_floats_assigned_via_attr_writers_on_another_object
@@ -103,7 +103,7 @@ module Custom
         end
       RUBY
 
-      assert_offense(described_class::PROPERTY_MSG)
+      assert_offense(cop.name, described_class::PROPERTY_MSG)
     end
 
     def test_ignores_magic_integers_as_arguments_to_methods_on_another_object
@@ -113,7 +113,7 @@ module Custom
         end
       RUBY
 
-      refute_offense
+      refute_offense(cop.name)
     end
 
     def test_ignores_magic_floats_as_arguments_to_methods_on_another_object
@@ -123,7 +123,7 @@ module Custom
         end
       RUBY
 
-      refute_offense
+      refute_offense(cop.name)
     end
 
     def test_ignores_magic_integers_as_arguments_to_methods_on_self
@@ -133,7 +133,7 @@ module Custom
         end
       RUBY
 
-      refute_offense
+      refute_offense(cop.name)
     end
 
     def test_ignores_magic_floats_as_arguments_to_methods_on_self
@@ -143,31 +143,7 @@ module Custom
         end
       RUBY
 
-      refute_offense
-    end
-
-    def test_detects_magic_integers_assigned_to_global_variables
-      inspect_source(<<~RUBY)
-        def test_method
-          $GLOBAL_VARIABLE = 1
-        end
-      RUBY
-
-      assert_no_offenses("Custom/NoMagicNumbers")
-
-      inspect_source(<<~RUBY)
-        $GLOBAL_VARIABLE = 1
-      RUBY
-
-      assert_no_offenses("Custom/NoMagicNumbers")
-    end
-
-    def test_detects_magic_floats_assigned_to_global_variables
-      inspect_source(<<~RUBY)
-        $GLOBAL_VARIABLE = 1.0
-      RUBY
-
-      assert_no_offenses("Custom/NoMagicNumbers")
+      refute_offense(cop.name)
     end
 
     def test_ignores_magic_integers_assigned_via_class_writers_on_another_object
@@ -177,7 +153,7 @@ module Custom
         end
       RUBY
 
-      refute_offense
+      refute_offense(cop.name)
     end
 
     def test_ignores_magic_floats_assigned_via_class_writers_on_another_object
@@ -187,7 +163,7 @@ module Custom
         end
       RUBY
 
-      refute_offense
+      refute_offense(cop.name)
     end
 
     private

--- a/test/lib/no_magic_numbers_test.rb
+++ b/test/lib/no_magic_numbers_test.rb
@@ -168,7 +168,6 @@ module Custom
       RUBY
 
       assert_no_offenses(cop.name)
-      refute_offense(cop.name)
     end
 
     def test_ignores_magic_integers_assigned_via_class_writers_on_another_object

--- a/test/lib/no_magic_numbers_test.rb
+++ b/test/lib/no_magic_numbers_test.rb
@@ -202,7 +202,7 @@ module Custom
     end
 
     def config
-      @config ||= RuboCop::Config.new(cop.name => { 'Enabled' => true })
+      @config ||= RuboCop::Config.new('Custom/NoMagicNumbers' => { 'Enabled' => true })
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,9 +7,9 @@ require 'rubocop'
 module TestHelper
   def assert_offense(cop_name = nil, violation_message = nil)
     matching_offenses = cop_name.nil? ? cop.offenses : cop.offenses.select { _1.cop_name == cop_name }
-    message = ["Expected an offense", "to be detected but there was none"]
+    message = ['Expected an offense', 'to be detected but there was none']
     message.insert(1, "named #{cop_name}") if cop_name
-    message_string = message.join(" ")
+    message_string = message.join(' ')
 
     refute_empty(matching_offenses, message_string)
     assert_equal(cop.offenses.first.message, violation_message) if cop.offenses.any?
@@ -17,7 +17,8 @@ module TestHelper
 
   def assert_no_offenses(cop_name = nil)
     matching_offenses = cop_name.nil? ? cop.offenses : cop.offenses.select { _1.cop_name == cop_name }
-    assert_empty(matching_offenses, "Expected no offense to be detected but there was one")
+
+    assert_empty(matching_offenses, 'Expected no offense to be detected but there was one')
   end
   alias refute_offense assert_no_offenses
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,8 +5,13 @@ require 'byebug'
 require 'rubocop'
 
 module TestHelper
-  def assert_offense(violation_message)
-    refute_empty(cop.offenses, "Expected a #{cop.cop_name} offense to be detected but there was none")
+  def assert_offense(cop_name = nil, violation_message = nil)
+    matching_offenses = cop_name.nil? ? cop.offenses : cop.offenses.select { _1.cop_name == cop_name }
+    message = ["Expected an offense", "to be detected but there was none"]
+    message.insert(1, "named #{cop_name}") if cop_name
+    message_string = message.join(" ")
+
+    refute_empty(matching_offenses, message_string)
     assert_equal(cop.offenses.first.message, violation_message) if cop.offenses.any?
   end
 


### PR DESCRIPTION
## What 

Refactor the `assert_offense` method to take the cop name (not the error message) as the first argument

## Why 

This allows us to more specifically assert the errors we expect to see 
