### PR TITLE
Add Rubocop github action

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,38 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Rubocop
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.2']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run Rubocop
+      run: bundle exec rubocop --parallel

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  lint:
 
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
As a rubocop gem, we ought to have a passing rubocop run!

https://github.com/Bodacious/no-magic-numbers-cop/pull/24 does the work to make the rubocops pass, so once that's merged this should be able to be green.