### PR TITLE
Fix Rubocop class naming inconsistency

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -5,7 +5,7 @@
 # This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
-name: Rubocop
+name: RuboCop
 
 on:
   push:
@@ -34,5 +34,5 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Run Rubocop
+    - name: Run RuboCop
       run: bundle exec rubocop --parallel

--- a/lib/rubocop/cop/magic_numbers/no_magic_numbers.rb
+++ b/lib/rubocop/cop/magic_numbers/no_magic_numbers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Rubocop
+module RuboCop
   module Cop
     module MagicNumbers
       # Adds violations for magic numbers, aka assignments to variables with bare

--- a/lib/rubocop/cop/magic_numbers/version.rb
+++ b/lib/rubocop/cop/magic_numbers/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Rubocop
+module RuboCop
   module Cop
     module MagicNumbers
       VERSION = '0.0.1'

--- a/lib/rubocop/no_magic_numbers.rb
+++ b/lib/rubocop/no_magic_numbers.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
+require 'rubocop/cop/magic_numbers/version'
 require 'rubocop/cop/magic_numbers/no_magic_numbers'
+require 'rubocop/cop/magic_numbers/no_magic_argument'

--- a/lib/rubocop/no_magic_numbers.rb
+++ b/lib/rubocop/no_magic_numbers.rb
@@ -2,4 +2,3 @@
 
 require 'rubocop/cop/magic_numbers/version'
 require 'rubocop/cop/magic_numbers/no_magic_numbers'
-require 'rubocop/cop/magic_numbers/no_magic_argument'

--- a/rubocop-magic_numbers.gemspec
+++ b/rubocop-magic_numbers.gemspec
@@ -5,7 +5,7 @@ require 'rubocop/cop/magic_numbers/version'
 
 Gem::Specification.new do |s|
   s.name = 'magic-numbers'
-  s.version = Rubocop::Cop::MagicNumbers::VERSION
+  s.version = RuboCop::Cop::MagicNumbers::VERSION
   s.summary = 'rubocop/magic_numbers implements a rubocop cop for detecting the use ' \
               'of bare numbers when linting'
   s.description = 'rubocop/magic_numbers implements a rubocop cop for detecting the use ' \

--- a/test/rubocop/cop/magic_numbers/no_magic_numbers_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_magic_numbers_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'RuboCop/no_magic_numbers'
+require 'rubocop/no_magic_numbers'
 
 module RuboCop
   module Cop

--- a/test/rubocop/cop/magic_numbers/no_magic_numbers_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_magic_numbers_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 require 'rubocop/no_magic_numbers'
 
-module Rubocop
+module RuboCop
   module Cop
     module MagicNumbers
       class NoMagicNumbersTest < Minitest::Test
@@ -241,46 +241,6 @@ module Rubocop
           )
         end
 
-        def test_ignores_magic_integers_as_arguments_to_methods_on_another_object
-          inspect_source(<<~RUBY)
-            def test_method
-              foo.inject(1)
-            end
-          RUBY
-
-          refute_offense(cop.name)
-        end
-
-        def test_ignores_magic_floats_as_arguments_to_methods_on_another_object
-          inspect_source(<<~RUBY)
-            def test_method
-              foo.inject(1.0)
-            end
-          RUBY
-
-          refute_offense(cop.name)
-        end
-
-        def test_ignores_magic_integers_as_arguments_to_methods_on_self
-          inspect_source(<<~RUBY)
-            def test_method
-              self.inject(1)
-            end
-          RUBY
-
-          refute_offense(cop.name)
-        end
-
-        def test_ignores_magic_floats_as_arguments_to_methods_on_self
-          inspect_source(<<~RUBY)
-            def test_method
-              self.inject(1.0)
-            end
-          RUBY
-
-          refute_offense(cop.name)
-        end
-
         def test_detects_magic_integers_assigned_to_global_variables
           inspect_source(<<~RUBY)
             def test_method
@@ -328,7 +288,7 @@ module Rubocop
         private
 
         def described_class
-          Rubocop::Cop::MagicNumbers::NoMagicNumbers
+          RuboCop::Cop::MagicNumbers::NoMagicNumbers
         end
 
         def cop

--- a/test/rubocop/cop/magic_numbers/no_magic_numbers_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_magic_numbers_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'rubocop/no_magic_numbers'
+require 'RuboCop/no_magic_numbers'
 
 module RuboCop
   module Cop

--- a/test/rubocop/cop/magic_numbers/no_magic_numbers_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_magic_numbers_test.rb
@@ -241,6 +241,46 @@ module RuboCop
           )
         end
 
+        def test_ignores_magic_integers_as_arguments_to_methods_on_another_object
+          inspect_source(<<~RUBY)
+            def test_method
+              foo.inject(1)
+            end
+          RUBY
+
+          refute_offense(cop.name)
+        end
+
+        def test_ignores_magic_floats_as_arguments_to_methods_on_another_object
+          inspect_source(<<~RUBY)
+            def test_method
+              foo.inject(1.0)
+            end
+          RUBY
+
+          refute_offense(cop.name)
+        end
+
+        def test_ignores_magic_integers_as_arguments_to_methods_on_self
+          inspect_source(<<~RUBY)
+            def test_method
+              self.inject(1)
+            end
+          RUBY
+
+          refute_offense(cop.name)
+        end
+
+        def test_ignores_magic_floats_as_arguments_to_methods_on_self
+          inspect_source(<<~RUBY)
+            def test_method
+              self.inject(1.0)
+            end
+          RUBY
+
+          refute_offense(cop.name)
+        end
+
         def test_detects_magic_integers_assigned_to_global_variables
           inspect_source(<<~RUBY)
             def test_method


### PR DESCRIPTION
RuboCop uses camel-case between Rubo and Cop.

This PR fixes the cases where the alternative `Rubocop` was used.