### PR TITLE
Extract magic argument into its own class

### DIFF
--- a/lib/rubocop/cop/magic_numbers/no_magic_argument.rb
+++ b/lib/rubocop/cop/magic_numbers/no_magic_argument.rb
@@ -3,7 +3,7 @@ require_relative "no_magic_numbers"
 module RuboCop
   module Cop
     module MagicNumbers
-      class NoMagicAssignment < NoMagicNumbers
+      class NoArgument < NoMagicNumbers
       end
     end
   end

--- a/lib/rubocop/cop/magic_numbers/no_magic_argument.rb
+++ b/lib/rubocop/cop/magic_numbers/no_magic_argument.rb
@@ -1,0 +1,10 @@
+require_relative "no_magic_numbers"
+
+module RuboCop
+  module Cop
+    module MagicNumbers
+      class NoMagicAssignment < NoMagicNumbers
+      end
+    end
+  end
+end

--- a/test/rubocop/cop/magic_numbers/no_magic_argument_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_magic_argument_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+require "rubocop/cop/magic_numbers/no_magic_argument"
+
+module RuboCop
+  module Cop
+    module MagicNumbers
+      class NoMagicAssignmentTest < ::Minitest::Test
+        def test_ignores_magic_integers_as_arguments_to_methods_on_another_object
+          inspect_source(<<~RUBY)
+            def test_method
+              foo.inject(1)
+            end
+          RUBY
+
+          refute_offense(cop.name)
+        end
+
+        def test_ignores_magic_floats_as_arguments_to_methods_on_another_object
+          inspect_source(<<~RUBY)
+            def test_method
+              foo.inject(1.0)
+            end
+          RUBY
+
+          refute_offense(cop.name)
+        end
+
+        def test_ignores_magic_integers_as_arguments_to_methods_on_self
+          inspect_source(<<~RUBY)
+            def test_method
+              self.inject(1)
+            end
+          RUBY
+
+          refute_offense(cop.name)
+        end
+
+        def test_ignores_magic_floats_as_arguments_to_methods_on_self
+          inspect_source(<<~RUBY)
+            def test_method
+              self.inject(1.0)
+            end
+          RUBY
+
+          refute_offense(cop.name)
+        end
+
+        private
+
+        def described_class
+          RuboCop::Cop::MagicNumbers::NoMagicAssignment
+        end
+
+        def cop
+          @cop ||= described_class.new(config)
+        end
+
+        def config
+          @config ||= RuboCop::Config.new('MagicNumbers/NoMagicAssignment' => { 'Enabled' => true })
+        end
+      end
+    end
+  end
+end

--- a/test/rubocop/cop/magic_numbers/no_magic_argument_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_magic_argument_test.rb
@@ -4,7 +4,7 @@ require "rubocop/cop/magic_numbers/no_magic_argument"
 module RuboCop
   module Cop
     module MagicNumbers
-      class NoMagicAssignmentTest < ::Minitest::Test
+      class NoArgumentTest < ::Minitest::Test
         def test_ignores_magic_integers_as_arguments_to_methods_on_another_object
           inspect_source(<<~RUBY)
             def test_method
@@ -48,7 +48,7 @@ module RuboCop
         private
 
         def described_class
-          RuboCop::Cop::MagicNumbers::NoMagicAssignment
+          RuboCop::Cop::MagicNumbers::NoArgument
         end
 
         def cop
@@ -56,7 +56,7 @@ module RuboCop
         end
 
         def config
-          @config ||= RuboCop::Config.new('MagicNumbers/NoMagicAssignment' => { 'Enabled' => true })
+          @config ||= RuboCop::Config.new('MagicNumbers/NoArgument' => { 'Enabled' => true })
         end
       end
     end

--- a/test/rubocop/cop/magic_numbers/no_magic_numbers_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_magic_numbers_test.rb
@@ -241,46 +241,6 @@ module RuboCop
           )
         end
 
-        def test_ignores_magic_integers_as_arguments_to_methods_on_another_object
-          inspect_source(<<~RUBY)
-            def test_method
-              foo.inject(1)
-            end
-          RUBY
-
-          refute_offense(cop.name)
-        end
-
-        def test_ignores_magic_floats_as_arguments_to_methods_on_another_object
-          inspect_source(<<~RUBY)
-            def test_method
-              foo.inject(1.0)
-            end
-          RUBY
-
-          refute_offense(cop.name)
-        end
-
-        def test_ignores_magic_integers_as_arguments_to_methods_on_self
-          inspect_source(<<~RUBY)
-            def test_method
-              self.inject(1)
-            end
-          RUBY
-
-          refute_offense(cop.name)
-        end
-
-        def test_ignores_magic_floats_as_arguments_to_methods_on_self
-          inspect_source(<<~RUBY)
-            def test_method
-              self.inject(1.0)
-            end
-          RUBY
-
-          refute_offense(cop.name)
-        end
-
         def test_detects_magic_integers_assigned_to_global_variables
           inspect_source(<<~RUBY)
             def test_method


### PR DESCRIPTION
Extracts the magic argument test into their own test file, and extends the main `NoMagicNumbers` class as `NoArgument` for future extraction (See #30)