### PR TITLE
Remove cop resets

### DIFF
--- a/test/rubocop/cop/magic_numbers/no_assignment/float/class_variable_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/float/class_variable_test.rb
@@ -11,7 +11,7 @@ module RuboCop
         module Float
           class ClassVariableTest < Minitest::Test
             def setup
-              @matched_numerics = TestHelper::FLOAT_LITERALS + ["a"]
+              @matched_numerics = TestHelper::FLOAT_LITERALS
             end
 
             def test_ignores_magic_numbers_assigned_to_class_variables

--- a/test/rubocop/cop/magic_numbers/no_assignment/float/class_variable_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/float/class_variable_test.rb
@@ -11,7 +11,7 @@ module RuboCop
         module Float
           class ClassVariableTest < Minitest::Test
             def setup
-              @matched_numerics = TestHelper::FLOAT_LITERALS
+              @matched_numerics = TestHelper::FLOAT_LITERALS + ["a"]
             end
 
             def test_ignores_magic_numbers_assigned_to_class_variables

--- a/test/rubocop/cop/magic_numbers/no_assignment/float/instance_variable_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/float/instance_variable_test.rb
@@ -23,8 +23,6 @@ module RuboCop
                 RUBY
 
                 assert_instance_variable_offense
-
-                reset_cop
               end
             end
 
@@ -43,10 +41,6 @@ module RuboCop
 
             def cop
               @cop ||= described_class.new(config)
-            end
-
-            def reset_cop
-              @cop = nil
             end
 
             def config

--- a/test/rubocop/cop/magic_numbers/no_assignment/float/local_variable_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/float/local_variable_test.rb
@@ -23,8 +23,6 @@ module RuboCop
                 RUBY
 
                 assert_local_variable_offense
-
-                reset_cop
               end
             end
 
@@ -43,10 +41,6 @@ module RuboCop
 
             def cop
               @cop ||= described_class.new(config)
-            end
-
-            def reset_cop
-              @cop = nil
             end
 
             def config

--- a/test/rubocop/cop/magic_numbers/no_assignment/float/setter_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/float/setter_test.rb
@@ -23,8 +23,6 @@ module RuboCop
                 RUBY
 
                 assert_property_offense
-
-                reset_cop
               end
             end
 
@@ -37,8 +35,6 @@ module RuboCop
                 RUBY
 
                 assert_property_offense
-
-                reset_cop
               end
             end
 
@@ -57,10 +53,6 @@ module RuboCop
 
             def cop
               @cop ||= described_class.new(config)
-            end
-
-            def reset_cop
-              @cop = nil
             end
 
             def config

--- a/test/rubocop/cop/magic_numbers/no_assignment/instance_variable_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/instance_variable_test.rb
@@ -23,8 +23,6 @@ module RuboCop
               RUBY
 
               assert_instance_variable_offense
-
-              reset_cop
             end
           end
 
@@ -43,10 +41,6 @@ module RuboCop
 
           def cop
             @cop ||= described_class.new(config)
-          end
-
-          def reset_cop
-            @cop = nil
           end
 
           def config

--- a/test/rubocop/cop/magic_numbers/no_assignment/integer/instance_variable_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/integer/instance_variable_test.rb
@@ -23,8 +23,6 @@ module RuboCop
                 RUBY
 
                 assert_instance_variable_offense
-
-                reset_cop
               end
             end
 
@@ -43,10 +41,6 @@ module RuboCop
 
             def cop
               @cop ||= described_class.new(config)
-            end
-
-            def reset_cop
-              @cop = nil
             end
 
             def config

--- a/test/rubocop/cop/magic_numbers/no_assignment/integer/local_variable_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/integer/local_variable_test.rb
@@ -23,8 +23,6 @@ module RuboCop
                 RUBY
 
                 assert_local_variable_offense
-
-                reset_cop
               end
             end
 
@@ -43,10 +41,6 @@ module RuboCop
 
             def cop
               @cop ||= described_class.new(config)
-            end
-
-            def reset_cop
-              @cop = nil
             end
 
             def config

--- a/test/rubocop/cop/magic_numbers/no_assignment/integer/setter_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/integer/setter_test.rb
@@ -23,8 +23,6 @@ module RuboCop
                 RUBY
 
                 assert_property_offense
-
-                reset_cop
               end
             end
 
@@ -37,8 +35,6 @@ module RuboCop
                 RUBY
 
                 assert_property_offense
-
-                reset_cop
               end
             end
 
@@ -57,10 +53,6 @@ module RuboCop
 
             def cop
               @cop ||= described_class.new(config)
-            end
-
-            def reset_cop
-              @cop = nil
             end
 
             def config

--- a/test/rubocop/cop/magic_numbers/no_assignment/local_variable_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/local_variable_test.rb
@@ -23,8 +23,6 @@ module RuboCop
               RUBY
 
               assert_local_variable_offense
-
-              reset_cop
             end
           end
 
@@ -43,10 +41,6 @@ module RuboCop
 
           def cop
             @cop ||= described_class.new(config)
-          end
-
-          def reset_cop
-            @cop = nil
           end
 
           def config

--- a/test/rubocop/cop/magic_numbers/no_assignment/setter_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/setter_test.rb
@@ -23,8 +23,6 @@ module RuboCop
               RUBY
 
               assert_property_offense
-
-              reset_cop
             end
           end
 
@@ -37,8 +35,6 @@ module RuboCop
               RUBY
 
               assert_property_offense
-
-              reset_cop
             end
           end
 
@@ -57,10 +53,6 @@ module RuboCop
 
           def cop
             @cop ||= described_class.new(config)
-          end
-
-          def reset_cop
-            @cop = nil
           end
 
           def config


### PR DESCRIPTION
I was wrong about this.

the `inspect_source` will automatically initialise a new inspection, which seems to reset the offences on a given cop