### PR TITLE
Add a base class for all cops in group

### DIFF
--- a/lib/rubocop/cop/magic_numbers/base.rb
+++ b/lib/rubocop/cop/magic_numbers/base.rb
@@ -1,0 +1,16 @@
+module RuboCop
+  module Cop
+    module MagicNumbers
+      class Base < ::RuboCop::Cop::Cop
+        ILLEGAL_SCALAR_TYPES = %i[float int].freeze
+        ILLEGAL_SCALAR_PATTERN = "{#{ILLEGAL_SCALAR_TYPES.join(" ")}".freeze
+
+        private
+
+        def node_matches_pattern?(node:, pattern:)
+          RuboCop::AST::NodePattern.new(pattern).match(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/magic_numbers/base.rb
+++ b/lib/rubocop/cop/magic_numbers/base.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module MagicNumbers
+      # Base class for all shared behaviour between these cops
       class Base < ::RuboCop::Cop::Cop
         ILLEGAL_SCALAR_TYPES = %i[float int].freeze
-        ILLEGAL_SCALAR_PATTERN = "{#{ILLEGAL_SCALAR_TYPES.join(" ")}".freeze
+        ILLEGAL_SCALAR_PATTERN = "{#{ILLEGAL_SCALAR_TYPES.join(' ')}".freeze
 
         private
 


### PR DESCRIPTION
## What

Adds a base class to move shared behaviour for all cops within this gem

## Why 

We're currently splitting the `NoMagicNumbers` class into separate classes for SRPs.  They currently still inherit from `NoMagicNumbers` in order to preserve the behaviour, but we want to move specific matchers into these classes and share behaviour across a single parent class.