### PR TITLE
Rename gem name in gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .byebug_history
 .bundle
 spec
+*.gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    magic-numbers (0.0.1)
+    rubocop-magic_numbers (0.0.1)
       parser
       rubocop
 
@@ -47,9 +47,9 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  magic-numbers!
   minitest
   rake
+  rubocop-magic_numbers!
   rubocop-minitest
   rubocop-rake
   rubocop-require_tools

--- a/rubocop-magic_numbers.gemspec
+++ b/rubocop-magic_numbers.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH << File.expand_path('lib', __dir__)
 require 'rubocop/cop/magic_numbers/version'
 
 Gem::Specification.new do |s|
-  s.name = 'magic-numbers'
+  s.name = 'rubocop-magic_numbers'
   s.version = RuboCop::Cop::MagicNumbers::VERSION
   s.summary = 'rubocop/magic_numbers implements a rubocop cop for detecting the use ' \
               'of bare numbers when linting'
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.authors = ['Gavin Morrice', 'Fell Sunderland']
   s.email = ['gavin@gavinmorrice.com', 'fell@meetcleo.com']
 
-  s.homepage = 'https://github.com/Bodacious/no-magic-numbers-cop'
+  s.homepage = 'https://github.com/Bodacious/rubocop-magic_numbers'
 
   s.add_dependency('parser')
   s.add_dependency('rubocop')


### PR DESCRIPTION
## What 

Renames gem to `rubocop-magic_numbers`

## Why 

This is a more conventional name for a RuboCop extension 

