### PR TITLE
Permit assignment with magic numbers outside of method definitions

### DIFF
--- a/lib/rubocop/cop/magic_numbers/base.rb
+++ b/lib/rubocop/cop/magic_numbers/base.rb
@@ -20,6 +20,8 @@ module RuboCop
           CONFIG_FLOAT => %i[float]
         }.freeze
 
+        NODE_TYPE_METHOD_DEFINITION = :def
+
         # The configuration for this cop, pre-set with defaults
         #
         # Returns Hash
@@ -56,6 +58,10 @@ module RuboCop
         # Returns Boolean
         def node_matches_pattern?(node:, pattern:)
           RuboCop::AST::NodePattern.new(pattern).match(node)
+        end
+
+        def node_within_method?(node)
+          node.ancestors.any? { _1.type == NODE_TYPE_METHOD_DEFINITION }
         end
       end
     end

--- a/lib/rubocop/cop/magic_numbers/base.rb
+++ b/lib/rubocop/cop/magic_numbers/base.rb
@@ -20,7 +20,6 @@ module RuboCop
           CONFIG_FLOAT => %i[float]
         }.freeze
 
-
         # The configuration for this cop, pre-set with defaults
         #
         # Returns Hash

--- a/lib/rubocop/cop/magic_numbers/base.rb
+++ b/lib/rubocop/cop/magic_numbers/base.rb
@@ -20,7 +20,6 @@ module RuboCop
           CONFIG_FLOAT => %i[float]
         }.freeze
 
-        NODE_TYPE_METHOD_DEFINITION = :def
 
         # The configuration for this cop, pre-set with defaults
         #
@@ -61,7 +60,7 @@ module RuboCop
         end
 
         def node_within_method?(node)
-          node.ancestors.any? { _1.type == NODE_TYPE_METHOD_DEFINITION }
+          node.ancestors.any?(&:def_type?)
         end
       end
     end

--- a/lib/rubocop/cop/magic_numbers/no_assignment.rb
+++ b/lib/rubocop/cop/magic_numbers/no_assignment.rb
@@ -41,6 +41,7 @@ module RuboCop
 
         def on_local_variable_assignment(node)
           return unless illegal_scalar_value?(node)
+          return unless node_within_method?(node)
 
           add_offense(node, location: :expression, message: LOCAL_VARIABLE_ASSIGN_MSG)
         end
@@ -48,6 +49,7 @@ module RuboCop
 
         def on_instance_variable_assignment(node)
           return unless illegal_scalar_value?(node)
+          return unless node_within_method?(node)
 
           add_offense(node, location: :expression, message: INSTANCE_VARIABLE_ASSIGN_MSG)
         end
@@ -55,6 +57,7 @@ module RuboCop
 
         def on_message_send(node)
           return unless illegal_scalar_argument_to_setter?(node)
+          return unless node_within_method?(node)
 
           add_offense(node, location: :expression, message: PROPERTY_MSG)
         end

--- a/lib/rubocop/cop/magic_numbers/no_return.rb
+++ b/lib/rubocop/cop/magic_numbers/no_return.rb
@@ -16,13 +16,13 @@ module RuboCop
         def on_def(node)
           return unless implicit_return?(node.children.last)
 
-          add_offense(node, location: :expression, message: NO_EXPLICIT_RETURN_MSG)
+          add_offense(node.children.last, location: :expression, message: NO_EXPLICIT_RETURN_MSG)
         end
 
         def on_return(node)
           return unless forbidden_numerics.include?(node.children.first&.type)
 
-          add_offense(node, location: :expression, message: NO_EXPLICIT_RETURN_MSG)
+          add_offense(node.children.first, location: :expression, message: NO_EXPLICIT_RETURN_MSG)
         end
 
         private

--- a/test/rubocop/cop/magic_numbers/no_assignment/class_variable_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/class_variable_test.rb
@@ -8,15 +8,18 @@ module RuboCop
     module MagicNumbers
       class NoAssignment
         class ClassVariableTest < Minitest::Test
-          def setup
-            # We detect floats or ints, so this is used in tests to check for both
-            @matched_numerics = TestHelper::FLOAT_LITERALS + TestHelper::INTEGER_LITERALS
+          def test_ignores_magic_numbers_assigned_to_class_variables_in_default_config
+            cop_class = described_class.new(config)
+
+            allowed_assignments = cop_class.cop_config['AllowedAssignments']
+
+            assert_includes(allowed_assignments, 'class_variables')
           end
 
-          def test_ignores_magic_numbers_assigned_to_class_variables
-            @matched_numerics.each do |num|
+          def test_ignores_magic_numbers_assigned_to_class_variables_by_default
+            matched_numerics.each do |num|
               inspect_source(<<~RUBY)
-                def test_method
+                class TestClass
                   @@class_variable = #{num}
                 end
               RUBY

--- a/test/rubocop/cop/magic_numbers/no_assignment/instance_variable_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/instance_variable_test.rb
@@ -8,13 +8,18 @@ module RuboCop
     module MagicNumbers
       class NoAssignment
         class InstanceVariableTest < Minitest::Test
-          def setup
-            # We detect floats or ints, so this is used in tests to check for both
-            @matched_numerics = TestHelper::FLOAT_LITERALS + TestHelper::INTEGER_LITERALS
+          def test_ignores_magic_numbers_assigned_to_ivars_outside_of_methods
+            matched_numerics.each do |num|
+              inspect_source(<<~RUBY)
+                @instance_variable = #{num}
+              RUBY
+
+              assert_no_offenses
+            end
           end
 
           def test_detects_magic_numbers_assigned_to_instance_variables
-            @matched_numerics.each do |num|
+            matched_numerics.each do |num|
               inspect_source(<<~RUBY)
                 def test_method
                   @instance_variable = #{num}

--- a/test/rubocop/cop/magic_numbers/no_assignment/integer/setter_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/integer/setter_test.rb
@@ -9,12 +9,8 @@ module RuboCop
       class NoAssignment
         module Integer
           class SetterTest < Minitest::Test
-            def setup
-              @matched_numerics = TestHelper::INTEGER_LITERALS
-            end
-
             def test_detects_magic_numbers_assigned_via_setters_on_self
-              @matched_numerics.each do |num|
+              matched_numerics(:integer).each do |num|
                 inspect_source(<<~RUBY)
                   def test_method
                     self.set_attribute = #{num}
@@ -26,7 +22,7 @@ module RuboCop
             end
 
             def test_detects_magic_numbers_assigned_via_setters_on_another_object
-              @matched_numerics.each do |num|
+              matched_numerics(:integer).each do |num|
                 inspect_source(<<~RUBY)
                   def test_method
                     foo.set_attribute = #{num}

--- a/test/rubocop/cop/magic_numbers/no_assignment/local_variable_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/local_variable_test.rb
@@ -8,13 +8,18 @@ module RuboCop
     module MagicNumbers
       class NoAssignment
         class LocalVariableTest < Minitest::Test
-          def setup
-            # We detect floats or ints, so this is used in tests to check for both
-            @matched_numerics = TestHelper::FLOAT_LITERALS + TestHelper::INTEGER_LITERALS
+          def test_ignores_magic_numbers_assigned_to_local_vars_outside_of_methods
+            matched_numerics.each do |num|
+              inspect_source(<<~RUBY)
+                local_variable = #{num}
+              RUBY
+
+              assert_no_offenses
+            end
           end
 
           def test_detects_magic_numbers_assigned_to_local_variables
-            @matched_numerics.each do |num|
+            matched_numerics.each do |num|
               inspect_source(<<~RUBY)
                 def test_method
                   local_variable = #{num}

--- a/test/rubocop/cop/magic_numbers/no_assignment/setter_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/setter_test.rb
@@ -8,13 +8,18 @@ module RuboCop
     module MagicNumbers
       class NoAssignment
         class SetterTest < Minitest::Test
-          def setup
-            # We detect floats or ints, so this is used in tests to check for both
-            @matched_numerics = TestHelper::FLOAT_LITERALS + TestHelper::INTEGER_LITERALS
+          def test_ignores_magic_numbers_assigned_via_setters_outside_of_methods
+            matched_numerics.each do |num|
+              inspect_source(<<~RUBY)
+                self.set_attribute = #{num}
+              RUBY
+
+              assert_no_offenses
+            end
           end
 
           def test_detects_magic_numbers_assigned_via_setters_on_self
-            @matched_numerics.each do |num|
+            matched_numerics.each do |num|
               inspect_source(<<~RUBY)
                 def test_method
                   self.set_attribute = #{num}
@@ -26,7 +31,7 @@ module RuboCop
           end
 
           def test_detects_magic_numbers_assigned_via_setters_on_another_object
-            @matched_numerics.each do |num|
+            matched_numerics.each do |num|
               inspect_source(<<~RUBY)
                 def test_method
                   foo.set_attribute = #{num}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ require 'rubocop/magic_numbers'
 module TestHelper
   FLOAT_LITERALS = %w[10.0 1e1 1.0E1].freeze
   INTEGER_LITERALS = %w[10 1_0].freeze
+  ALL_LITERALS = (FLOAT_LITERALS | INTEGER_LITERALS).freeze
 
   def assert_offense(cop_name: nil, violation_message: nil)
     matching_offenses = matching_offenses_for_cop_name(cop_name)
@@ -28,9 +29,9 @@ module TestHelper
 
   private
 
-  def matched_numerics(type)
-    unless %i[float integer].include?(type.to_sym)
-      raise ArgumentError, "type must be one of float or int but was #{type}"
+  def matched_numerics(type = :all)
+    unless %i[all float integer].include?(type.to_sym)
+      raise ArgumentError, "type must be one of all, float, or integer but was #{type}"
     end
 
     TestHelper.const_get("#{type.to_s.upcase}_LITERALS")


### PR DESCRIPTION
## What 

This PR adds extra test cases and conditionally checks that violations occur within method definitions 

## Why 

There are cases where we want to tolerate magic numbers. For example, in configuration files

## How 

Checks a node has a `def` ancestor before applying the offence 