### PR TITLE
Fix test cases where NoReturns was failing

### DIFF
--- a/lib/rubocop/cop/magic_numbers/no_return.rb
+++ b/lib/rubocop/cop/magic_numbers/no_return.rb
@@ -28,6 +28,8 @@ module RuboCop
         private
 
         def implicit_return?(node)
+          return implicit_return?(node.children.last) if node.begin_type?
+
           pattern = format(MAGIC_NUMBER_RETURN_PATTERN, {
                              illegal_scalar_pattern:
                            })

--- a/test/rubocop/cop/magic_numbers/all_cops_test.rb
+++ b/test/rubocop/cop/magic_numbers/all_cops_test.rb
@@ -131,8 +131,6 @@ module RuboCop
         end
 
         def test_detects_magic_numbers_implicitly_returned_from_methods_after_other_things
-          skip('Currently not working')
-
           matched_numerics.each do |num|
             inspect_source(<<~RUBY, cops: all_cops)
               def test_method

--- a/test/rubocop/cop/magic_numbers/no_return/float/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/float/no_return_test.rb
@@ -56,8 +56,6 @@ module RuboCop
           end
 
           def test_when_a_method_implicitly_returns_a_float_after_other_things
-            skip('Currently not working')
-
             matched_numerics(:float).each do |num|
               inspect_source(<<~RUBY)
                 def test_method

--- a/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
@@ -56,8 +56,6 @@ module RuboCop
           end
 
           def test_when_a_method_implicitly_returns_an_integer_after_other_things
-            skip('Currently not working')
-
             matched_numerics(:integer).each do |num|
               inspect_source(<<~RUBY)
                 def test_method


### PR DESCRIPTION
Clone of https://github.com/Bodacious/rubocop-magic_numbers/pull/48, which got merged in accidentally because it didn't have anything upstream of its parent branch 

## What 

Fixes `NoReturn` in cases  where the behaviour wasn't working as desired.

See this PR for more info https://github.com/Bodacious/rubocop-magic_numbers/pull/45

## How 

Checks that the current node isn't a `begin` wrapper node before inspecting its child nodes.  I don't _love_ this approach, but wanted to get something out of the door before 2:30 this afternoon 