### PR TITLE
Allow magic numbers when argument is a collection position index

### DIFF
--- a/lib/rubocop/cop/magic_numbers/no_argument.rb
+++ b/lib/rubocop/cop/magic_numbers/no_argument.rb
@@ -44,6 +44,18 @@ module RuboCop
 
         ARGUMENT_MSG = 'Do not use magic number arguments to methods'
 
+        CONFIG_IGNORED_METHODS_NAME = "IgnoredMethods"
+
+        # By default, don't raise an offense for magic numbers arguments
+        # for these methods
+        DEFAULT_CONFIG = {
+          CONFIG_IGNORED_METHODS_NAME => ['[]']
+        }
+
+        def cop_config
+          super.merge(DEFAULT_CONFIG)
+        end
+
         def on_method_defined(node)
           return unless illegal_positional_default?(node)
 
@@ -57,12 +69,23 @@ module RuboCop
 
         def on_message_send(node)
           return unless illegal_argument?(node)
+          return if ignored_method?(node)
 
           add_offense(node, location: :expression, message: ARGUMENT_MSG)
         end
         alias on_send on_message_send # rubocop API method name
 
         private
+
+        def ignored_method?(node)
+          return false unless node.respond_to?(:method_name)
+
+          ignored_methods.include?(node.method_name)
+        end
+
+        def ignored_methods
+          Array(cop_config[CONFIG_IGNORED_METHODS_NAME]).map(&:to_sym)
+        end
 
         def illegal_positional_default?(node)
           node_matches_pattern?(

--- a/lib/rubocop/cop/magic_numbers/no_argument.rb
+++ b/lib/rubocop/cop/magic_numbers/no_argument.rb
@@ -44,13 +44,13 @@ module RuboCop
 
         ARGUMENT_MSG = 'Do not use magic number arguments to methods'
 
-        CONFIG_IGNORED_METHODS_NAME = "IgnoredMethods"
+        CONFIG_IGNORED_METHODS_NAME = 'IgnoredMethods'
 
         # By default, don't raise an offense for magic numbers arguments
         # for these methods
         DEFAULT_CONFIG = {
           CONFIG_IGNORED_METHODS_NAME => ['[]']
-        }
+        }.freeze
 
         def cop_config
           super.merge(DEFAULT_CONFIG)

--- a/test/rubocop/cop/magic_numbers/no_argument/method_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_argument/method_test.rb
@@ -48,6 +48,16 @@ module RuboCop
             end
           end
 
+          def test_allows_magic_numbers_in_square_bracket_enum_index_arguments
+            matched_numerics(:integer).each do |num|
+              inspect_source(<<~RUBY)
+                my_collection[#{num}]
+              RUBY
+
+              assert_no_offenses
+            end
+          end
+
           private
 
           def assert_argument_offense
@@ -55,10 +65,6 @@ module RuboCop
               cop_name: cop.name,
               violation_message: described_class::ARGUMENT_MSG
             )
-          end
-
-          def matched_numerics
-            TestHelper::FLOAT_LITERALS + TestHelper::INTEGER_LITERALS
           end
 
           def described_class


### PR DESCRIPTION
## What

Allow magic numbers when they are used to return an item at a given position within a collection:

``` ruby
collection[0] # => "I'm the first item"
```

## Why

This is a commonly used pattern and, while not ideal, might make this cop unusable if we tried to apply this rule on a large codebase

## How

Adds the method named `:[]` to an optional allowed set of method names. This behaviour can be disabled by updating the config:

``` ruby
MagicNumbers/NoArgument:
  IgnoredMethods: []
```
