### PR TITLE
Add configuration to allow implicit or explicit reutrns

### DIFF
--- a/lib/rubocop/cop/magic_numbers/base.rb
+++ b/lib/rubocop/cop/magic_numbers/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rubocop/cop/cop'
+
 module RuboCop
   module Cop
     module MagicNumbers

--- a/test/rubocop/cop/magic_numbers/no_return/float/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/float/no_return_test.rb
@@ -91,6 +91,27 @@ module RuboCop
             end
           end
 
+          def test_allows_explicit_return_of_a_float_when_config_set
+            update_config({
+                            'MagicNumbers/NoReturn' => {
+                              'Enabled' => true,
+                              'ForbiddenNumerics' => 'Float',
+                              'AllowedReturns' => ['Explicit']
+                            }
+                          })
+            matched_numerics(:float).each do |num|
+              inspect_source(<<~RUBY)
+                def test_method
+                  return #{num}
+
+                  other_method
+                end
+              RUBY
+
+              assert_no_offenses(cop_name:)
+            end
+          end
+
           private
 
           def described_class

--- a/test/rubocop/cop/magic_numbers/no_return/float/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/float/no_return_test.rb
@@ -72,6 +72,25 @@ module RuboCop
             end
           end
 
+          def test_allows_implicit_return_of_a_float_when_config_set
+            update_config({
+                            'MagicNumbers/NoReturn' => {
+                              'Enabled' => true,
+                              'ForbiddenNumerics' => 'Float',
+                              'AllowedReturns' => ['Implicit']
+                            }
+                          })
+            matched_numerics(:float).each do |num|
+              inspect_source(<<~RUBY)
+                def test_method
+                  #{num}
+                end
+              RUBY
+
+              assert_no_offenses(cop_name:)
+            end
+          end
+
           private
 
           def described_class

--- a/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
@@ -91,6 +91,27 @@ module RuboCop
             end
           end
 
+          def test_allows_explicit_return_of_an_integer_when_config_set
+            update_config({
+                            'MagicNumbers/NoReturn' => {
+                              'Enabled' => true,
+                              'ForbiddenNumerics' => 'Integer',
+                              'AllowedReturns' => ['Explicit']
+                            }
+                          })
+            matched_numerics(:integer).each do |num|
+              inspect_source(<<~RUBY)
+                def test_method
+                  return #{num}
+
+                  other_method
+                end
+              RUBY
+
+              assert_no_offenses(cop_name:)
+            end
+          end
+
           private
 
           def described_class

--- a/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
@@ -72,6 +72,25 @@ module RuboCop
             end
           end
 
+          def test_allows_implicit_return_of_an_integer_when_config_set
+            update_config({
+                            'MagicNumbers/NoReturn' => {
+                              'Enabled' => true,
+                              'ForbiddenNumerics' => 'Integer',
+                              'AllowedReturns' => ['Implicit']
+                            }
+                          })
+            matched_numerics(:integer).each do |num|
+              inspect_source(<<~RUBY)
+                def test_method
+                  #{num}
+                end
+              RUBY
+
+              assert_no_offenses(cop_name:)
+            end
+          end
+
           private
 
           def described_class

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -98,8 +98,18 @@ module TestHelper
     raise NotImplementedError, "Please define `cop' in your test"
   end
 
+  def update_config(updated_config = {})
+    remove_instance_variable(:@config) if defined?(@config)
+
+    set_config(updated_config)
+  end
+
   def config
-    @config ||= RuboCop::Config.new(hash)
+    @config ||= set_config
+  end
+
+  def set_config(hash = {})
+    RuboCop::Config.new(hash)
   end
 
   def matching_offenses_for_cop_name(cop_name)


### PR DESCRIPTION
## What 

Extend `MagicNumbers::NoReturns` to be configurable to allow `"Implicit"`, `"Explicit"`, or `"None"` (default)

## Why 

As raised in https://github.com/Bodacious/rubocop-magic_numbers/issues/54, I think it's reasonable to assume that some teams will want to allow this pattern. 

## How

- Add support for a configuration called `AllowedReturns`, that accepts one of `"Implicit"`, `"Explicit"`, or `"None"` (default)
- Add tests
