### PR TITLE
Accept permitted values config for NoArgument cop

### DIFF
--- a/lib/rubocop/cop/magic_numbers/no_argument.rb
+++ b/lib/rubocop/cop/magic_numbers/no_argument.rb
@@ -18,9 +18,9 @@ module RuboCop
             {
               _
               _
-              (%<illegal_scalar_pattern>s _)
+              (%<illegal_scalar_pattern>s $_)
               | # This is a union of lhs and rhs literal
-              (%<illegal_scalar_pattern>s _)
+              (%<illegal_scalar_pattern>s $_)
               _
               _
             }
@@ -62,13 +62,18 @@ module RuboCop
         end
 
         def illegal_argument?(node)
-          node_matches_pattern?(
+          captured_value = node_matches_pattern?(
             node:,
             pattern: format(
               MAGIC_NUMBER_ARGUMENT_PATTERN,
               illegal_scalar_pattern:
             )
           )
+          captured_value.present? && !permitted_values.include?(captured_value)
+        end
+
+        def permitted_values
+          Array(cop_config['PermittedValues'])
         end
       end
     end

--- a/lib/rubocop/cop/magic_numbers/no_argument.rb
+++ b/lib/rubocop/cop/magic_numbers/no_argument.rb
@@ -69,7 +69,7 @@ module RuboCop
               illegal_scalar_pattern:
             )
           )
-          captured_value.present? && !permitted_values.include?(captured_value)
+          captured_value && !permitted_values.include?(captured_value)
         end
 
         def permitted_values

--- a/test/rubocop/cop/magic_numbers/no_argument/float/method_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_argument/float/method_test.rb
@@ -9,6 +9,8 @@ module RuboCop
       class NoArgument
         module Float
           class MethodTest < Minitest::Test
+            ARBITRARY_FLOAT_TO_PERMIT = 3.14
+
             def test_detects_magic_numbers_used_as_arguments_to_methods
               matched_numerics(:float).each do |num|
                 inspect_source(<<~RUBY)
@@ -47,6 +49,66 @@ module RuboCop
 
                 assert_argument_offense
               end
+            end
+
+            def test_allows_magic_floats_permitted_in_config_when_left_operand
+              @config = RuboCop::Config.new({
+                                              'MagicNumbers/NoArgument' => {
+                                                'PermittedValues' => [ARBITRARY_FLOAT_TO_PERMIT]
+                                              }
+                                            })
+              @cop = described_class.new(config)
+
+              inspect_source(<<~RUBY)
+                #{ARBITRARY_FLOAT_TO_PERMIT} + bar
+              RUBY
+
+              assert_no_offenses('MagicNumbers/NoArgument')
+            end
+
+            def test_allows_magic_floats_permitted_in_config_when_right_operand
+              @config = RuboCop::Config.new({
+                                              'MagicNumbers/NoArgument' => {
+                                                'PermittedValues' => [ARBITRARY_FLOAT_TO_PERMIT]
+                                              }
+                                            })
+              @cop = described_class.new(config)
+
+              inspect_source(<<~RUBY)
+                foo + #{ARBITRARY_FLOAT_TO_PERMIT}
+              RUBY
+
+              assert_no_offenses('MagicNumbers/NoArgument')
+            end
+
+            def test_allows_magic_floats_permitted_in_config_as_positional_arg
+              @config = RuboCop::Config.new({
+                                              'MagicNumbers/NoArgument' => {
+                                                'PermittedValues' => [ARBITRARY_FLOAT_TO_PERMIT]
+                                              }
+                                            })
+              @cop = described_class.new(config)
+
+              inspect_source(<<~RUBY)
+                object.call(#{ARBITRARY_FLOAT_TO_PERMIT})
+              RUBY
+
+              assert_no_offenses('MagicNumbers/NoArgument')
+            end
+
+            def test_allows_magic_floats_permitted_in_config_as_keyword_arg
+              @config = RuboCop::Config.new({
+                                              'MagicNumbers/NoArgument' => {
+                                                'PermittedValues' => [ARBITRARY_FLOAT_TO_PERMIT]
+                                              }
+                                            })
+              @cop = described_class.new(config)
+
+              inspect_source(<<~RUBY)
+                object.call(val: #{ARBITRARY_FLOAT_TO_PERMIT})
+              RUBY
+
+              assert_no_offenses('MagicNumbers/NoArgument')
             end
 
             private

--- a/test/rubocop/cop/magic_numbers/no_argument/integer/method_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_argument/integer/method_test.rb
@@ -51,6 +51,15 @@ module RuboCop
               end
             end
 
+            # Explicitly tests this popular use case
+            def test_allows_magic_integers_permitted_in_config_used_with_increment
+              inspect_source(<<~RUBY)
+                foo += #{ARBITRARY_INTEGER_TO_PERMIT}
+              RUBY
+
+              assert_no_offenses
+            end
+
             def test_allows_magic_integers_permitted_in_config_when_left_operand
               @config = RuboCop::Config.new({
                                               'MagicNumbers/NoArgument' => {

--- a/test/rubocop/cop/magic_numbers/no_argument/integer/method_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_argument/integer/method_test.rb
@@ -9,6 +9,8 @@ module RuboCop
       class NoArgument
         module Integer
           class MethodTest < Minitest::Test
+            ARBITRARY_INTEGER_TO_PERMIT = 5
+
             def test_detects_magic_numbers_used_as_arguments_to_methods
               matched_numerics(:integer).each do |num|
                 inspect_source(<<~RUBY)
@@ -47,6 +49,66 @@ module RuboCop
 
                 assert_argument_offense
               end
+            end
+
+            def test_allows_magic_integers_permitted_in_config_when_left_operand
+              @config = RuboCop::Config.new({
+                                              'MagicNumbers/NoArgument' => {
+                                                'PermittedValues' => [ARBITRARY_INTEGER_TO_PERMIT]
+                                              }
+                                            })
+              @cop = described_class.new(config)
+
+              inspect_source(<<~RUBY)
+                #{ARBITRARY_INTEGER_TO_PERMIT} + bar
+              RUBY
+
+              assert_no_offenses('MagicNumbers/NoArgument')
+            end
+
+            def test_allows_magic_integers_permitted_in_config_when_right_operand
+              @config = RuboCop::Config.new({
+                                              'MagicNumbers/NoArgument' => {
+                                                'PermittedValues' => [ARBITRARY_INTEGER_TO_PERMIT]
+                                              }
+                                            })
+              @cop = described_class.new(config)
+
+              inspect_source(<<~RUBY)
+                foo + #{ARBITRARY_INTEGER_TO_PERMIT}
+              RUBY
+
+              assert_no_offenses('MagicNumbers/NoArgument')
+            end
+
+            def test_allows_magic_integers_permitted_in_config_as_positional_arg
+              @config = RuboCop::Config.new({
+                                              'MagicNumbers/NoArgument' => {
+                                                'PermittedValues' => [ARBITRARY_INTEGER_TO_PERMIT]
+                                              }
+                                            })
+              @cop = described_class.new(config)
+
+              inspect_source(<<~RUBY)
+                object.call(#{ARBITRARY_INTEGER_TO_PERMIT})
+              RUBY
+
+              assert_no_offenses('MagicNumbers/NoArgument')
+            end
+
+            def test_allows_magic_integers_permitted_in_config_as_keyword_arg
+              @config = RuboCop::Config.new({
+                                              'MagicNumbers/NoArgument' => {
+                                                'PermittedValues' => [ARBITRARY_INTEGER_TO_PERMIT]
+                                              }
+                                            })
+              @cop = described_class.new(config)
+
+              inspect_source(<<~RUBY)
+                object.call(val: #{ARBITRARY_INTEGER_TO_PERMIT})
+              RUBY
+
+              assert_no_offenses('MagicNumbers/NoArgument')
             end
 
             private


### PR DESCRIPTION
## What 

Allows us to set a configuration for `NoArgument` cop.

This allows teams to allow certain values that are commonly understood.

``` ruby 
@users.each do |user|
  users_count += 1 if user.active?
end

User.where(nil).limit(1)

@users.active.count == 0
```

## Why 

This would seem like a popular concern, and these changes reduce the barriers to implementing this

