### PR TITLE
Support Ruby 2.7 and higher

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   NewCops: enable
   SuggestExtensions: true
+  TargetRubyVersion: 2.7
 
 require:
   - rubocop-rake

--- a/lib/rubocop/cop/magic_numbers/no_argument.rb
+++ b/lib/rubocop/cop/magic_numbers/no_argument.rb
@@ -63,10 +63,10 @@ module RuboCop
 
         def illegal_argument?(node)
           captured_value = node_matches_pattern?(
-            node:,
+            node: node,
             pattern: format(
               MAGIC_NUMBER_ARGUMENT_PATTERN,
-              illegal_scalar_pattern:
+              illegal_scalar_pattern: illegal_scalar_pattern
             )
           )
           captured_value && !permitted_values.include?(captured_value)

--- a/lib/rubocop/cop/magic_numbers/no_assignment.rb
+++ b/lib/rubocop/cop/magic_numbers/no_assignment.rb
@@ -77,10 +77,10 @@ module RuboCop
 
         def illegal_scalar_argument_to_setter?(node)
           method = node_matches_pattern?(
-            node:,
+            node: node,
             pattern: format(
               MAGIC_NUMBER_ARGUMENT_TO_SETTER_PATTERN,
-              illegal_scalar_pattern:
+              illegal_scalar_pattern: illegal_scalar_pattern
             )
           )
 
@@ -89,10 +89,10 @@ module RuboCop
 
         def illegal_multi_assign_right_hand_side?(node)
           node_matches_pattern?(
-            node:,
+            node: node,
             pattern: format(
               MAGIC_NUMBER_MULTI_ASSIGN_PATTERN,
-              illegal_scalar_pattern:
+              illegal_scalar_pattern: illegal_scalar_pattern
             )
           )
         end

--- a/lib/rubocop/cop/magic_numbers/no_default.rb
+++ b/lib/rubocop/cop/magic_numbers/no_default.rb
@@ -44,10 +44,10 @@ module RuboCop
 
         def illegal_positional_default?(node)
           node_matches_pattern?(
-            node:,
+            node: node,
             pattern: format(
               MAGIC_NUMBER_OPTIONAL_ARGUMENT_PATTERN,
-              illegal_scalar_pattern:
+              illegal_scalar_pattern: illegal_scalar_pattern
             )
           )
         end

--- a/lib/rubocop/cop/magic_numbers/no_return.rb
+++ b/lib/rubocop/cop/magic_numbers/no_return.rb
@@ -54,9 +54,9 @@ module RuboCop
           return implicit_return?(node.children.last) if is_node_begin_type
 
           pattern = format(MAGIC_NUMBER_RETURN_PATTERN, {
-                             illegal_scalar_pattern:
+                             illegal_scalar_pattern: illegal_scalar_pattern
                            })
-          node_matches_pattern?(node:, pattern:)
+          node_matches_pattern?(node: node, pattern: pattern)
         end
       end
     end

--- a/rubocop-magic_numbers.gemspec
+++ b/rubocop-magic_numbers.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     %w[README.md]
 
   s.require_path = 'lib'
-  s.required_ruby_version = Gem::Requirement.new('>= 3.2.0')
+  s.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
 
   s.authors = ['Gavin Morrice', 'Fell Sunderland']
   s.email = ['gavin@gavinmorrice.com', 'fell@meetcleo.com']

--- a/test/rubocop/cop/magic_numbers/no_return/float/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/float/no_return_test.rb
@@ -17,7 +17,7 @@ module RuboCop
               RUBY
 
               assert_offense(
-                cop_name:,
+                cop_name: cop_name,
                 violation_message: described_class::NO_EXPLICIT_RETURN_MSG
               )
             end
@@ -34,7 +34,7 @@ module RuboCop
               RUBY
 
               assert_offense(
-                cop_name:,
+                cop_name: cop_name,
                 violation_message: described_class::NO_EXPLICIT_RETURN_MSG
               )
             end
@@ -49,7 +49,7 @@ module RuboCop
               RUBY
 
               assert_offense(
-                cop_name:,
+                cop_name: cop_name,
                 violation_message: described_class::NO_EXPLICIT_RETURN_MSG
               )
             end
@@ -66,7 +66,7 @@ module RuboCop
               RUBY
 
               assert_offense(
-                cop_name:,
+                cop_name: cop_name,
                 violation_message: described_class::NO_EXPLICIT_RETURN_MSG
               )
             end
@@ -87,7 +87,7 @@ module RuboCop
                 end
               RUBY
 
-              assert_no_offenses(cop_name:)
+              assert_no_offenses(cop_name: cop_name)
             end
           end
 
@@ -108,7 +108,7 @@ module RuboCop
                 end
               RUBY
 
-              assert_no_offenses(cop_name:)
+              assert_no_offenses(cop_name: cop_name)
             end
           end
 

--- a/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
@@ -17,7 +17,7 @@ module RuboCop
               RUBY
 
               assert_offense(
-                cop_name:,
+                cop_name: cop_name,
                 violation_message: described_class::NO_EXPLICIT_RETURN_MSG
               )
             end
@@ -34,7 +34,7 @@ module RuboCop
               RUBY
 
               assert_offense(
-                cop_name:,
+                cop_name: cop_name,
                 violation_message: described_class::NO_EXPLICIT_RETURN_MSG
               )
             end
@@ -49,7 +49,7 @@ module RuboCop
               RUBY
 
               assert_offense(
-                cop_name:,
+                cop_name: cop_name,
                 violation_message: described_class::NO_EXPLICIT_RETURN_MSG
               )
             end
@@ -66,7 +66,7 @@ module RuboCop
               RUBY
 
               assert_offense(
-                cop_name:,
+                cop_name: cop_name,
                 violation_message: described_class::NO_EXPLICIT_RETURN_MSG
               )
             end
@@ -87,7 +87,7 @@ module RuboCop
                 end
               RUBY
 
-              assert_no_offenses(cop_name:)
+              assert_no_offenses(cop_name: cop_name)
             end
           end
 
@@ -108,7 +108,7 @@ module RuboCop
                 end
               RUBY
 
-              assert_no_offenses(cop_name:)
+              assert_no_offenses(cop_name: cop_name)
             end
           end
 


### PR DESCRIPTION
## What was done as a part of this PR?

- Added support for Ruby 2.7, 3.0, and 3.1.

## Why it was done?

- Ruby 2.7, 3.0, and 3.1 are still very popular and widely utilized.
- [rubocop-magic_numbers](https://github.com/meetcleo/rubocop-magic_numbers) functionality would be beneficial for all of them.

## How it was done?

- Updated minimal Ruby version to 2.7 in `gemspec`.
- Changed target version to Ruby 2.7 in `.rubocop.yml`. 
- Removed [hash shorthand syntax](https://rubyreferences.github.io/rubychanges/3.1.html#values-in-hash-literals-and-keyword-arguments-can-be-omitted) in the codebase.

## How it was tested?

- Using a local [fork](https://github.com/marian13/rubocop-magic_numbers) with `bundle exec rake`.
  <img width="720" alt="Screenshot 2023-07-14 at 00 09 04" src="https://github.com/meetcleo/rubocop-magic_numbers/assets/22632866/3918fe98-373c-48c8-a780-70333d571cf8">

- Using [local Convenient Service](https://github.com/marian13/convenient_service/pull/88/files) gem.
  <img width="720" alt="Screenshot 2023-07-14 at 00 16 30" src="https://github.com/meetcleo/rubocop-magic_numbers/assets/22632866/353a9176-4b92-4228-8fa7-6cf2937c8901">
  
  <img width="720" alt="Screenshot 2023-07-14 at 00 16 37" src="https://github.com/meetcleo/rubocop-magic_numbers/assets/22632866/aefdb1d1-0b64-4893-ae98-c418da196558">

- Using [CI of Convenient Service](https://github.com/marian13/convenient_service/actions/runs/5548057915/jobs/10130541142?pr=88) gem.
   
  <img width="720" alt="Screenshot 2023-07-14 at 00 28 45" src="https://github.com/meetcleo/rubocop-magic_numbers/assets/22632866/545dfb0a-804e-4ae7-8716-a908e375d25b">

## Notes

- Thanks for developing [rubocop-magic_numbers](https://github.com/meetcleo/rubocop-magic_numbers).



