### PR TITLE
Bump gem version to 0.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-magic_numbers (0.3.0)
+    rubocop-magic_numbers (0.4.0)
       parser
       rubocop
 

--- a/lib/rubocop/magic_numbers/version.rb
+++ b/lib/rubocop/magic_numbers/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module MagicNumbers
-    VERSION = '0.3.0'
+    VERSION = '0.4.0'
   end
 end


### PR DESCRIPTION
Prepare version 0.4.0 for release.

This minor release adds support for older versions of Ruby to 2.7.0