### PR TITLE
PermittedReturnValues for NoReturn cop

### DIFF
--- a/test/rubocop/cop/magic_numbers/no_argument/float/method_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_argument/float/method_test.rb
@@ -63,7 +63,7 @@ module RuboCop
                 #{ARBITRARY_FLOAT_TO_PERMIT} + bar
               RUBY
 
-              assert_no_offenses(cop_name:)
+              assert_no_offenses(cop_name: cop_name)
             end
 
             def test_allows_magic_floats_permitted_in_config_when_right_operand
@@ -78,7 +78,7 @@ module RuboCop
                 foo + #{ARBITRARY_FLOAT_TO_PERMIT}
               RUBY
 
-              assert_no_offenses(cop_name:)
+              assert_no_offenses(cop_name: cop_name)
             end
 
             def test_allows_magic_floats_permitted_in_config_as_positional_arg
@@ -93,7 +93,7 @@ module RuboCop
                 object.call(#{ARBITRARY_FLOAT_TO_PERMIT})
               RUBY
 
-              assert_no_offenses(cop_name:)
+              assert_no_offenses(cop_name: cop_name)
             end
 
             def test_allows_magic_floats_permitted_in_config_as_keyword_arg
@@ -108,7 +108,7 @@ module RuboCop
                 object.call(val: #{ARBITRARY_FLOAT_TO_PERMIT})
               RUBY
 
-              assert_no_offenses(cop_name:)
+              assert_no_offenses(cop_name: cop_name)
             end
 
             private

--- a/test/rubocop/cop/magic_numbers/no_argument/float/method_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_argument/float/method_test.rb
@@ -63,7 +63,7 @@ module RuboCop
                 #{ARBITRARY_FLOAT_TO_PERMIT} + bar
               RUBY
 
-              assert_no_offenses('MagicNumbers/NoArgument')
+              assert_no_offenses(cop_name:)
             end
 
             def test_allows_magic_floats_permitted_in_config_when_right_operand
@@ -78,7 +78,7 @@ module RuboCop
                 foo + #{ARBITRARY_FLOAT_TO_PERMIT}
               RUBY
 
-              assert_no_offenses('MagicNumbers/NoArgument')
+              assert_no_offenses(cop_name:)
             end
 
             def test_allows_magic_floats_permitted_in_config_as_positional_arg
@@ -93,7 +93,7 @@ module RuboCop
                 object.call(#{ARBITRARY_FLOAT_TO_PERMIT})
               RUBY
 
-              assert_no_offenses('MagicNumbers/NoArgument')
+              assert_no_offenses(cop_name:)
             end
 
             def test_allows_magic_floats_permitted_in_config_as_keyword_arg
@@ -108,7 +108,7 @@ module RuboCop
                 object.call(val: #{ARBITRARY_FLOAT_TO_PERMIT})
               RUBY
 
-              assert_no_offenses('MagicNumbers/NoArgument')
+              assert_no_offenses(cop_name:)
             end
 
             private
@@ -126,6 +126,10 @@ module RuboCop
 
             def cop
               @cop ||= described_class.new(config)
+            end
+
+            def cop_name
+              cop.cop_name
             end
 
             def config

--- a/test/rubocop/cop/magic_numbers/no_argument/integer/method_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_argument/integer/method_test.rb
@@ -72,7 +72,7 @@ module RuboCop
                 #{ARBITRARY_INTEGER_TO_PERMIT} + bar
               RUBY
 
-              assert_no_offenses('MagicNumbers/NoArgument')
+              assert_no_offenses(cop_name:)
             end
 
             def test_allows_magic_integers_permitted_in_config_when_right_operand
@@ -87,7 +87,7 @@ module RuboCop
                 foo + #{ARBITRARY_INTEGER_TO_PERMIT}
               RUBY
 
-              assert_no_offenses('MagicNumbers/NoArgument')
+              assert_no_offenses(cop_name:)
             end
 
             def test_allows_magic_integers_permitted_in_config_as_positional_arg
@@ -102,13 +102,13 @@ module RuboCop
                 object.call(#{ARBITRARY_INTEGER_TO_PERMIT})
               RUBY
 
-              assert_no_offenses('MagicNumbers/NoArgument')
+              assert_no_offenses(cop_name:)
             end
 
             def test_allows_magic_integers_permitted_in_config_as_keyword_arg
               @config = RuboCop::Config.new({
                                               'MagicNumbers/NoArgument' => {
-                                                'PermittedValues' => [ARBITRARY_INTEGER_TO_PERMIT]
+                                                'PermittedValues' => []
                                               }
                                             })
               @cop = described_class.new(config)
@@ -117,7 +117,7 @@ module RuboCop
                 object.call(val: #{ARBITRARY_INTEGER_TO_PERMIT})
               RUBY
 
-              assert_no_offenses('MagicNumbers/NoArgument')
+              assert_no_offenses(cop_name:)
             end
 
             private
@@ -135,6 +135,10 @@ module RuboCop
 
             def cop
               @cop ||= described_class.new(config)
+            end
+
+            def cop_name
+              cop.cop_name
             end
 
             def config

--- a/test/rubocop/cop/magic_numbers/no_argument/integer/method_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_argument/integer/method_test.rb
@@ -72,7 +72,7 @@ module RuboCop
                 #{ARBITRARY_INTEGER_TO_PERMIT} + bar
               RUBY
 
-              assert_no_offenses(cop_name:)
+              assert_no_offenses(cop_name: cop_name)
             end
 
             def test_allows_magic_integers_permitted_in_config_when_right_operand
@@ -87,7 +87,7 @@ module RuboCop
                 foo + #{ARBITRARY_INTEGER_TO_PERMIT}
               RUBY
 
-              assert_no_offenses(cop_name:)
+              assert_no_offenses(cop_name: cop_name)
             end
 
             def test_allows_magic_integers_permitted_in_config_as_positional_arg
@@ -102,7 +102,7 @@ module RuboCop
                 object.call(#{ARBITRARY_INTEGER_TO_PERMIT})
               RUBY
 
-              assert_no_offenses(cop_name:)
+              assert_no_offenses(cop_name: cop_name)
             end
 
             def test_allows_magic_integers_permitted_in_config_as_keyword_arg
@@ -117,7 +117,7 @@ module RuboCop
                 object.call(val: #{ARBITRARY_INTEGER_TO_PERMIT})
               RUBY
 
-              assert_no_offenses(cop_name:)
+              assert_no_offenses(cop_name: cop_name)
             end
 
             private

--- a/test/rubocop/cop/magic_numbers/no_return/float/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/float/no_return_test.rb
@@ -73,13 +73,13 @@ module RuboCop
           end
 
           def test_allows_implicit_return_of_a_float_when_config_set
-            @config = update_config({
-                            'MagicNumbers/NoReturn' => {
-                              'Enabled' => true,
-                              'ForbiddenNumerics' => 'Float',
-                              'AllowedReturns' => ['Implicit']
-                            }
-                          })
+            @config = RuboCop::Config.new({
+                                            'MagicNumbers/NoReturn' => {
+                                              'Enabled' => true,
+                                              'ForbiddenNumerics' => 'Float',
+                                              'AllowedReturns' => ['Implicit']
+                                            }
+                                          })
             @cop = described_class.new(config)
 
             matched_numerics(:float).each do |num|
@@ -94,13 +94,13 @@ module RuboCop
           end
 
           def test_allows_explicit_return_of_a_float_when_config_set
-            @config = update_config({
-                            'MagicNumbers/NoReturn' => {
-                              'Enabled' => true,
-                              'ForbiddenNumerics' => 'Float',
-                              'AllowedReturns' => ['Explicit']
-                            }
-                          })
+            @config = RuboCop::Config.new({
+                                            'MagicNumbers/NoReturn' => {
+                                              'Enabled' => true,
+                                              'ForbiddenNumerics' => 'Float',
+                                              'AllowedReturns' => ['Explicit']
+                                            }
+                                          })
             @cop = described_class.new(config)
 
             matched_numerics(:float).each do |num|

--- a/test/rubocop/cop/magic_numbers/no_return/float/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/float/no_return_test.rb
@@ -73,13 +73,15 @@ module RuboCop
           end
 
           def test_allows_implicit_return_of_a_float_when_config_set
-            update_config({
+            @config = update_config({
                             'MagicNumbers/NoReturn' => {
                               'Enabled' => true,
                               'ForbiddenNumerics' => 'Float',
                               'AllowedReturns' => ['Implicit']
                             }
                           })
+            @cop = described_class.new(config)
+
             matched_numerics(:float).each do |num|
               inspect_source(<<~RUBY)
                 def test_method
@@ -92,13 +94,15 @@ module RuboCop
           end
 
           def test_allows_explicit_return_of_a_float_when_config_set
-            update_config({
+            @config = update_config({
                             'MagicNumbers/NoReturn' => {
                               'Enabled' => true,
                               'ForbiddenNumerics' => 'Float',
                               'AllowedReturns' => ['Explicit']
                             }
                           })
+            @cop = described_class.new(config)
+
             matched_numerics(:float).each do |num|
               inspect_source(<<~RUBY)
                 def test_method

--- a/test/rubocop/cop/magic_numbers/no_return/float/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/float/no_return_test.rb
@@ -8,6 +8,8 @@ module RuboCop
     module MagicNumbers
       module Float
         class NoReturnTest < ::Minitest::Test
+          ARBITRARY_FLOAT_TO_PERMIT = 5.0
+
           def test_when_a_method_explicitly_returns_a_float
             matched_numerics(:float).each do |num|
               inspect_source(<<~RUBY)
@@ -114,6 +116,27 @@ module RuboCop
 
               assert_no_offenses(cop_name: cop_name)
             end
+          end
+
+          def test_allows_explicit_return_of_an_integer_when_config_set
+            @config = RuboCop::Config.new({
+                                            'MagicNumbers/NoReturn' => {
+                                              'Enabled' => true,
+                                              'ForbiddenNumerics' => 'Integer',
+                                              'PermittedReturnValues' => [ARBITRARY_FLOAT_TO_PERMIT]
+                                            }
+                                          })
+            @cop = described_class.new(config)
+
+            inspect_source(<<~RUBY)
+              def test_method
+                return #{ARBITRARY_FLOAT_TO_PERMIT}
+
+                #{ARBITRARY_FLOAT_TO_PERMIT}
+              end
+            RUBY
+
+            assert_no_offenses(cop_name: cop_name)
           end
 
           private

--- a/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
@@ -75,13 +75,13 @@ module RuboCop
           end
 
           def test_allows_implicit_return_of_an_integer_when_config_set
-            @config = update_config({
-                            'MagicNumbers/NoReturn' => {
-                              'Enabled' => true,
-                              'ForbiddenNumerics' => 'Integer',
-                              'AllowedReturns' => ['Implicit']
-                            }
-                          })
+            @config = RuboCop::Config.new({
+                                            'MagicNumbers/NoReturn' => {
+                                              'Enabled' => true,
+                                              'ForbiddenNumerics' => 'Integer',
+                                              'AllowedReturns' => ['Implicit']
+                                            }
+                                          })
             @cop = described_class.new(config)
 
             matched_numerics(:integer).each do |num|
@@ -96,13 +96,13 @@ module RuboCop
           end
 
           def test_allows_explicit_return_of_an_integer_when_config_set
-            @config = update_config({
-                            'MagicNumbers/NoReturn' => {
-                              'Enabled' => true,
-                              'ForbiddenNumerics' => 'Integer',
-                              'AllowedReturns' => ['Explicit']
-                            }
-                          })
+            @config = RuboCop::Config.new({
+                                            'MagicNumbers/NoReturn' => {
+                                              'Enabled' => true,
+                                              'ForbiddenNumerics' => 'Integer',
+                                              'AllowedReturns' => ['Explicit']
+                                            }
+                                          })
             @cop = described_class.new(config)
 
             matched_numerics(:integer).each do |num|

--- a/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
@@ -8,6 +8,8 @@ module RuboCop
     module MagicNumbers
       module Integer
         class NoReturnTest < ::Minitest::Test
+          ARBITRARY_INTEGER_TO_PERMIT = 5
+
           def test_when_a_method_explicitly_returns_an_integer
             matched_numerics(:integer).each do |num|
               inspect_source(<<~RUBY)
@@ -73,13 +75,15 @@ module RuboCop
           end
 
           def test_allows_implicit_return_of_an_integer_when_config_set
-            update_config({
+            @config = update_config({
                             'MagicNumbers/NoReturn' => {
                               'Enabled' => true,
                               'ForbiddenNumerics' => 'Integer',
                               'AllowedReturns' => ['Implicit']
                             }
                           })
+            @cop = described_class.new(config)
+
             matched_numerics(:integer).each do |num|
               inspect_source(<<~RUBY)
                 def test_method
@@ -92,13 +96,15 @@ module RuboCop
           end
 
           def test_allows_explicit_return_of_an_integer_when_config_set
-            update_config({
+            @config = update_config({
                             'MagicNumbers/NoReturn' => {
                               'Enabled' => true,
                               'ForbiddenNumerics' => 'Integer',
                               'AllowedReturns' => ['Explicit']
                             }
                           })
+            @cop = described_class.new(config)
+
             matched_numerics(:integer).each do |num|
               inspect_source(<<~RUBY)
                 def test_method

--- a/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
@@ -118,6 +118,27 @@ module RuboCop
             end
           end
 
+          def test_allows_explicit_return_of_an_integer_when_config_set
+            @config = RuboCop::Config.new({
+                                            'MagicNumbers/NoReturn' => {
+                                              'Enabled' => true,
+                                              'ForbiddenNumerics' => 'Integer',
+                                              'PermittedReturnValues' => [ARBITRARY_INTEGER_TO_PERMIT]
+                                            }
+                                          })
+            @cop = described_class.new(config)
+
+            inspect_source(<<~RUBY)
+              def test_method
+                return #{ARBITRARY_INTEGER_TO_PERMIT}
+
+                #{ARBITRARY_INTEGER_TO_PERMIT}
+              end
+            RUBY
+
+            assert_no_offenses(cop_name: cop_name)
+          end
+
           private
 
           def described_class

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,7 @@ module TestHelper
     assert_equal(matching_offenses.first.message, violation_message) if matching_offenses.any?
   end
 
-  def assert_no_offenses(cop_name = nil)
+  def assert_no_offenses(cop_name: nil)
     raise NotImplementedError, "Please call `inspect_source' before making assertions" unless @offenses
 
     matching_offenses = cop_name.nil? ? @offenses : @offenses.select { _1.cop_name == cop_name }


### PR DESCRIPTION
## Context

We encountered a use case within our company that we extended the `NoReturn` cop to allow configuration for `PermittedReturnValues`, similar to the `NoArgument/PermittedValues` configuration. 

Thought it might be useful for others.

## What's in this PR

### Fixed false negatives in tests
I found some bugs in test suite that was producing false negatives

### Introduced the new NoReturn/PermittedReturnValues config
Added config that would allow predetermined list of not-so-magical numbers to be returned. This configuration covers both explicit & implicit returns.

```yaml
MagicNumbers/NoReturn:
  PermittedReturnValues:
    - 0
    - 0.0
```

```ruby
def foo
  return 0 if return_zero  # ok
  return 1 if return_one # not ok what is this magic number

  0.0 # ok
end
```
---

Also .. thanks for the awesome cop! 😃 