### PR TITLE
Fix README incorrect cop name

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ MagicNumbers/NoArgument:
 MagicNumbers/NoAssignment:
   ForbiddenNumerics: All/Float/Integer # default All
 
-MagicNumbers/Default:
+MagicNumbers/NoDefault:
   ForbiddenNumerics: All/Float/Integer # default All
 
 MagicNumbers/NoReturn:


### PR DESCRIPTION
Fixed typo: `MagicNumbers/Default` -> `MagicNumbers/NoDefault`