### PR TITLE
Add permitted values to NoAssignment cop

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ first, second = 0, 1
 
 # Still detected as an offense
 retry_limit = 3
+first, second = 2
 first, second = 0, 2
 first, second = 2, 0
 first, second = 2, 3

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ MagicNumbers/NoArgument:
     - 1
 MagicNumbers/NoAssignment:
   ForbiddenNumerics: All/Float/Integer # default All
+  PermittedValues: # defaults to []
+    - 0
+    - 1
 
 MagicNumbers/NoDefault:
   ForbiddenNumerics: All/Float/Integer # default All
@@ -130,6 +133,24 @@ MagicNumbers/NoDefault:
 MagicNumbers/NoReturn:
   AllowedReturns: Implicit/Explicit/None # default None
   ForbiddenNumerics: All/Float/Integer # default All
+```
+
+`MagicNumbers/NoAssignment` can be configured with `PermittedValues` when some
+assigned values do not need the same explanation as other numeric values. This
+allows configured values in local variable, instance variable, property, and
+multiple assignments. Unpermitted magic numbers are still detected:
+
+```ruby
+# Allowed when MagicNumbers/NoAssignment permits 0 and 1
+count = 0
+@total = 1
+first, second = 0, 1
+
+# Still detected as an offense
+retry_limit = 3
+first, second = 0, 2
+first, second = 2, 0
+first, second = 2, 3
 ```
 
 For more information on configuring `rubocop`, please refer to the [official documentation](https://docs.rubocop.org/rubocop/configuration.html).

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ MagicNumbers/NoAssignment:
   PermittedValues: # defaults to []
     - 0
     - 1
+    - 3.14
 
 MagicNumbers/NoDefault:
   ForbiddenNumerics: All/Float/Integer # default All

--- a/lib/rubocop/cop/magic_numbers/no_assignment.rb
+++ b/lib/rubocop/cop/magic_numbers/no_assignment.rb
@@ -17,14 +17,14 @@ module RuboCop
           (send
             ({send self} ...)
             $_
-            (%<illegal_scalar_pattern>s _)
+            $(%<illegal_scalar_pattern>s _)
           )
         PATTERN
 
         MAGIC_NUMBER_MULTI_ASSIGN_PATTERN = <<-PATTERN
           (masgn
             (mlhs ({lvasgn ivasgn send} ...)+)
-            (array <(%<illegal_scalar_pattern>s _) ...>)
+            $(array <(%<illegal_scalar_pattern>s _) ...>)
           )
         PATTERN
         LOCAL_VARIABLE_ASSIGN_MSG = 'Do not use magic number local variables'
@@ -32,7 +32,8 @@ module RuboCop
         MULTIPLE_ASSIGN_MSG = 'Do not use magic numbers in multiple assignments'
         PROPERTY_MSG = 'Do not use magic numbers to set properties'
         DEFAULT_CONFIG = {
-          'AllowedAssignments' => %w[class_variables global_variables]
+          'AllowedAssignments' => %w[class_variables global_variables],
+          'PermittedValues' => []
         }.freeze
 
         def cop_config
@@ -76,7 +77,7 @@ module RuboCop
         private
 
         def illegal_scalar_argument_to_setter?(node)
-          method = node_matches_pattern?(
+          method, value = node_matches_pattern?(
             node: node,
             pattern: format(
               MAGIC_NUMBER_ARGUMENT_TO_SETTER_PATTERN,
@@ -84,17 +85,19 @@ module RuboCop
             )
           )
 
-          method&.end_with?('=')
+          method&.end_with?('=') && illegal_scalar_expression?(value)
         end
 
         def illegal_multi_assign_right_hand_side?(node)
-          node_matches_pattern?(
+          multiple_assignment_value = node_matches_pattern?(
             node: node,
             pattern: format(
               MAGIC_NUMBER_MULTI_ASSIGN_PATTERN,
               illegal_scalar_pattern: illegal_scalar_pattern
             )
           )
+
+          illegal_scalar_expressions(multiple_assignment_value).any?
         end
 
         def illegal_scalar_value?(node)
@@ -103,7 +106,28 @@ module RuboCop
           # multiassignment nodes contain individual assignments in their AST
           # representations, but they aren't aware of their values, so we need to
           # allow for expressionless assignments
-          forbidden_numerics.include?(node.expression&.type)
+          illegal_scalar_expression?(node.expression)
+        end
+
+        def illegal_scalar_expression?(expression)
+          return false unless expression
+          return false unless forbidden_numerics.include?(expression.type)
+
+          !permitted_value?(expression.value)
+        end
+
+        def illegal_scalar_expressions(expression)
+          return [] unless expression
+
+          expression.children.select { |child_expression| illegal_scalar_expression?(child_expression) }
+        end
+
+        def permitted_value?(value)
+          permitted_values.include?(value)
+        end
+
+        def permitted_values
+          Array(cop_config['PermittedValues'])
         end
       end
     end

--- a/lib/rubocop/cop/magic_numbers/no_assignment.rb
+++ b/lib/rubocop/cop/magic_numbers/no_assignment.rb
@@ -24,7 +24,10 @@ module RuboCop
         MAGIC_NUMBER_MULTI_ASSIGN_PATTERN = <<-PATTERN
           (masgn
             (mlhs ({lvasgn ivasgn send} ...)+)
-            $(array <(%<illegal_scalar_pattern>s _) ...>)
+            {
+              $(%<illegal_scalar_pattern>s _)
+              $(array <(%<illegal_scalar_pattern>s _) ...>)
+            }
           )
         PATTERN
         LOCAL_VARIABLE_ASSIGN_MSG = 'Do not use magic number local variables'
@@ -119,7 +122,8 @@ module RuboCop
         def illegal_scalar_expressions(expression)
           return [] unless expression
 
-          expression.children.select { |child_expression| illegal_scalar_expression?(child_expression) }
+          expressions = expression.array_type? ? expression.children : [expression]
+          expressions.select { |child_expression| illegal_scalar_expression?(child_expression) }
         end
 
         def permitted_value?(value)

--- a/test/rubocop/cop/magic_numbers/no_assignment/permitted_values_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/permitted_values_test.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'test_helper'
+
+module RuboCop
+  module Cop
+    module MagicNumbers
+      class NoAssignment
+        class PermittedValuesTest < Minitest::Test
+          def test_permitted_values_defaults_to_empty
+            default_config = RuboCop::Config.new('MagicNumbers/NoAssignment' => { 'Enabled' => true })
+
+            assert_empty(described_class.new(default_config).cop_config['PermittedValues'])
+          end
+
+          def test_allows_permitted_values_assigned_to_variables_and_properties
+            inspect_source(<<~RUBY)
+              def test_method
+                local_variable = 0
+                @instance_variable = 1
+                self.property = 0.0
+                first, second = 0, 1
+              end
+            RUBY
+
+            assert_no_offenses
+          end
+
+          def test_detects_unpermitted_local_variable_assignment
+            inspect_source(<<~RUBY)
+              def test_method
+                local_variable = 10
+              end
+            RUBY
+
+            assert_offense(
+              cop_name: cop.name,
+              violation_message: described_class::LOCAL_VARIABLE_ASSIGN_MSG
+            )
+          end
+
+          def test_detects_unpermitted_instance_variable_assignment
+            inspect_source(<<~RUBY)
+              def test_method
+                @instance_variable = 10
+              end
+            RUBY
+
+            assert_offense(
+              cop_name: cop.name,
+              violation_message: described_class::INSTANCE_VARIABLE_ASSIGN_MSG
+            )
+          end
+
+          def test_detects_unpermitted_property_assignment
+            inspect_source(<<~RUBY)
+              def test_method
+                self.property = 10
+              end
+            RUBY
+
+            assert_offense(
+              cop_name: cop.name,
+              violation_message: described_class::PROPERTY_MSG
+            )
+          end
+
+          def test_detects_multiple_assignment_when_unpermitted_value_follows_permitted_value
+            inspect_source(<<~RUBY)
+              def test_method
+                first, second = 0, 2
+              end
+            RUBY
+
+            assert_multiple_assignment_offense
+          end
+
+          def test_detects_multiple_assignment_when_unpermitted_value_precedes_permitted_value
+            inspect_source(<<~RUBY)
+              def test_method
+                first, second = 2, 0
+              end
+            RUBY
+
+            assert_multiple_assignment_offense
+          end
+
+          def test_detects_multiple_assignment_when_values_are_wrapped_in_array
+            inspect_source(<<~RUBY)
+              def test_method
+                first, second = [0, 2]
+              end
+            RUBY
+
+            assert_multiple_assignment_offense
+          end
+
+          def test_allows_multiple_assignment_when_wrapped_array_values_are_permitted
+            inspect_source(<<~RUBY)
+              def test_method
+                first, second = [0, 1]
+              end
+            RUBY
+
+            assert_no_offenses
+          end
+
+          def test_allows_permitted_float_assignment
+            @config = RuboCop::Config.new(
+              'MagicNumbers/NoAssignment' => {
+                'Enabled' => true,
+                'PermittedValues' => [3.14]
+              }
+            )
+            @cop = described_class.new(config)
+
+            inspect_source(<<~RUBY)
+              def test_method
+                local_variable = 3.14
+                @instance_variable = 3.14
+                self.property = 3.14
+                first, second = 3.14, 3.14
+              end
+            RUBY
+
+            assert_no_offenses
+          end
+
+          def test_ignores_index_assignment
+            inspect_source(<<~RUBY)
+              def test_method
+                values[0] = 1
+              end
+            RUBY
+
+            assert_no_offenses
+          end
+
+          private
+
+          def assert_multiple_assignment_offense
+            assert_offense(
+              cop_name: cop.name,
+              violation_message: described_class::MULTIPLE_ASSIGN_MSG
+            )
+          end
+
+          def described_class
+            RuboCop::Cop::MagicNumbers::NoAssignment
+          end
+
+          def cop
+            @cop ||= described_class.new(config)
+          end
+
+          def config
+            @config ||= RuboCop::Config.new(
+              'MagicNumbers/NoAssignment' => {
+                'Enabled' => true,
+                'PermittedValues' => [0, 1]
+              }
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/rubocop/cop/magic_numbers/no_assignment/permitted_values_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_assignment/permitted_values_test.rb
@@ -106,6 +106,26 @@ module RuboCop
             assert_no_offenses
           end
 
+          def test_detects_multiple_assignment_with_single_unpermitted_right_hand_side_value
+            inspect_source(<<~RUBY)
+              def test_method
+                first, second = 2
+              end
+            RUBY
+
+            assert_multiple_assignment_offense
+          end
+
+          def test_allows_multiple_assignment_with_single_permitted_right_hand_side_value
+            inspect_source(<<~RUBY)
+              def test_method
+                first, second = 1
+              end
+            RUBY
+
+            assert_no_offenses
+          end
+
           def test_allows_permitted_float_assignment
             @config = RuboCop::Config.new(
               'MagicNumbers/NoAssignment' => {


### PR DESCRIPTION
## Summary

Add `PermittedValues` support to `MagicNumbers/NoAssignment`, matching the existing configuration style used by `MagicNumbers/NoArgument`.

## Why

Some numeric assignments are intentionally self-explanatory defaults, such as `0`, `1`, or project-specific sentinel values. Without a permitted-values list, teams have to either disable `MagicNumbers/NoAssignment` or loosen enforcement for every assignment just to avoid noise from those values.

This also fixes a bug in the first implementation: the multiple-assignment handling could miss unpermitted values after a permitted value because the extra filtering logic no longer let the node pattern drive the whole RHS check. The updated implementation keeps multiple-assignment detection pattern-led, then filters the captured numeric nodes against `PermittedValues`.

## Changes

- Added `PermittedValues` support for local variable, instance variable, setter, and multiple assignment checks
- Preserved default behavior by making `PermittedValues` default to `[]`
- Documented the `MagicNumbers/NoAssignment` configuration in the README
- Added tests for permitted and unpermitted values across assignment types, including multiple-assignment regression coverage

## Example

```yaml
MagicNumbers/NoAssignment:
  PermittedValues:
    - 0
    - 1
```
