### PR TITLE
Fix CI on ubuntu-24.04 runners

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -27,10 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,10 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
+++ b/test/rubocop/cop/magic_numbers/no_return/integer/no_return_test.rb
@@ -118,7 +118,7 @@ module RuboCop
             end
           end
 
-          def test_allows_explicit_return_of_an_integer_when_config_set
+          def test_allows_permitted_explicit_return_value_when_config_set
             @config = RuboCop::Config.new({
                                             'MagicNumbers/NoReturn' => {
                                               'Enabled' => true,


### PR DESCRIPTION
## Summary
- Update both CI workflows to use `ruby/setup-ruby@v1` instead of the pinned v1.146.0 commit.
- Rename the duplicate NoReturn integer test method so RuboCop no longer fails on `Lint/DuplicateMethods`.

## Why
The pinned `ruby/setup-ruby` commit does not recognize the current `ubuntu-24.04` GitHub-hosted runner image correctly, so CI fails during Ruby setup before tests or linting run. Once Ruby setup is fixed, the existing duplicate test method causes the RuboCop job to fail.
