### PR TITLE
Bump rubocop-magic_numbers to 0.6.0

### DIFF
--- a/lib/rubocop/magic_numbers/version.rb
+++ b/lib/rubocop/magic_numbers/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module MagicNumbers
-    VERSION = '0.5.0'
+    VERSION = '0.6.0'
   end
 end


### PR DESCRIPTION
So we can have the permitted values from #71 